### PR TITLE
feat: support cross-tenant transfer return workflow

### DIFF
--- a/Modules/Adjustment/DataTables/StockTransfersDataTable.php
+++ b/Modules/Adjustment/DataTables/StockTransfersDataTable.php
@@ -48,12 +48,11 @@ class StockTransfersDataTable extends DataTable
                 $q->whereHas('originLocation.setting', function ($q1) use ($settingId) {
                     $q1->where('id', $settingId);
                 })
-                    // 2) OR: transfers where current setting is the DESTINATION AND status is DISPATCHED
+                    // 2) OR: transfers where current setting is the DESTINATION regardless of status
                     ->orWhere(function($q2) use ($settingId) {
                         $q2->whereHas('destinationLocation.setting', function ($q3) use ($settingId) {
                             $q3->where('id', $settingId);
-                        })
-                            ->where('status', 'DISPATCHED');
+                        });
                     });
             });
     }

--- a/Modules/Adjustment/DataTables/StockTransfersDataTable.php
+++ b/Modules/Adjustment/DataTables/StockTransfersDataTable.php
@@ -19,6 +19,9 @@ class StockTransfersDataTable extends DataTable
     {
         return datatables()
             ->eloquent($query)
+            ->editColumn('document_number', function ($data) {
+                return $data->document_number ?? '-';
+            })
             ->addColumn('action', function ($data) {
                 return view('adjustment::transfers.partials.actions', compact('data'));
             })
@@ -66,7 +69,7 @@ class StockTransfersDataTable extends DataTable
             ->dom("<'row'<'col-md-3'l><'col-md-5 mb-2'B><'col-md-4'f>> .
                                         'tr' .
                                         <'row'<'col-md-5'i><'col-md-7 mt-2'p>>")
-            ->orderBy(4)
+            ->orderBy(0, 'desc')
             ->buttons(
                 Button::make('excel')
                     ->text('<i class="bi bi-file-earmark-excel-fill"></i> Excel'),
@@ -82,6 +85,10 @@ class StockTransfersDataTable extends DataTable
     protected function getColumns(): array
     {
         return [
+            Column::make('document_number')
+                ->title('No. Dokumen')
+                ->className('text-center align-middle'),
+
             Column::make('created_at')
                 ->title('Tanggal Transfer')
                 ->className('text-center align-middle'),

--- a/Modules/Adjustment/DataTables/StockTransfersDataTable.php
+++ b/Modules/Adjustment/DataTables/StockTransfersDataTable.php
@@ -32,10 +32,42 @@ class StockTransfersDataTable extends DataTable
                 return $data->created_at ? $data->created_at->format('Y-m-d H:i:s') : '-';
             })
             ->addColumn('origin_location_name', function ($data) {
-                return $data->originLocation ? $data->originLocation->name : '-';
+                $location = $data->originLocation;
+
+                if (! $location) {
+                    return '-';
+                }
+
+                $name            = $location->name ?? '-';
+                $currentSetting  = session('setting_id');
+                $locationSetting = $location->setting_id;
+
+                if ($locationSetting && (string) $locationSetting !== (string) $currentSetting) {
+                    $tenant = optional($location->setting)->company_name ?? ('Setting #' . $locationSetting);
+
+                    return sprintf('%s (%s)', $name, $tenant);
+                }
+
+                return $name;
             })
             ->addColumn('destination_location_name', function ($data) {
-                return $data->destinationLocation ? $data->destinationLocation->name : '-';
+                $location = $data->destinationLocation;
+
+                if (! $location) {
+                    return '-';
+                }
+
+                $name            = $location->name ?? '-';
+                $currentSetting  = session('setting_id');
+                $locationSetting = $location->setting_id;
+
+                if ($locationSetting && (string) $locationSetting !== (string) $currentSetting) {
+                    $tenant = optional($location->setting)->company_name ?? ('Setting #' . $locationSetting);
+
+                    return sprintf('%s (%s)', $name, $tenant);
+                }
+
+                return $name;
             });
     }
 
@@ -45,7 +77,7 @@ class StockTransfersDataTable extends DataTable
         $settingId = session('setting_id');
 
         return $model->newQuery()
-            ->with('originLocation', 'destinationLocation')
+            ->with(['originLocation.setting', 'destinationLocation.setting'])
             ->where(function($q) use ($settingId) {
                 // 1) All transfers where current setting is the ORIGIN
                 $q->whereHas('originLocation.setting', function ($q1) use ($settingId) {

--- a/Modules/Adjustment/Database/Migrations/2025_09_05_120000_add_return_flow_to_transfers_table.php
+++ b/Modules/Adjustment/Database/Migrations/2025_09_05_120000_add_return_flow_to_transfers_table.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('transfers', function (Blueprint $table) {
+            if (! Schema::hasColumn('transfers', 'return_dispatched_by')) {
+                $table->unsignedBigInteger('return_dispatched_by')->nullable()->after('dispatched_by');
+                $table->timestamp('return_dispatched_at')->nullable()->after('return_dispatched_by');
+                $table->index('return_dispatched_by', 'transfers_return_dispatched_by_index');
+                $table->foreign('return_dispatched_by', 'transfers_return_dispatched_by_foreign')
+                    ->references('id')
+                    ->on('users')
+                    ->nullOnDelete();
+            }
+
+            if (! Schema::hasColumn('transfers', 'return_received_by')) {
+                $table->unsignedBigInteger('return_received_by')->nullable()->after('return_dispatched_at');
+                $table->timestamp('return_received_at')->nullable()->after('return_received_by');
+                $table->index('return_received_by', 'transfers_return_received_by_index');
+                $table->foreign('return_received_by', 'transfers_return_received_by_foreign')
+                    ->references('id')
+                    ->on('users')
+                    ->nullOnDelete();
+            }
+        });
+
+        DB::statement("ALTER TABLE `transfers` MODIFY `status` ENUM('PENDING','APPROVED','REJECTED','DISPATCHED','RECEIVED','RETURN_DISPATCHED','RETURN_RECEIVED') NOT NULL DEFAULT 'PENDING'");
+    }
+
+    public function down(): void
+    {
+        DB::statement("ALTER TABLE `transfers` MODIFY `status` ENUM('PENDING','APPROVED','REJECTED','DISPATCHED','RECEIVED') NOT NULL DEFAULT 'PENDING'");
+
+        Schema::table('transfers', function (Blueprint $table) {
+            if (Schema::hasColumn('transfers', 'return_received_by')) {
+                $table->dropForeign('transfers_return_received_by_foreign');
+                $table->dropIndex('transfers_return_received_by_index');
+                $table->dropColumn(['return_received_by', 'return_received_at']);
+            }
+            if (Schema::hasColumn('transfers', 'return_dispatched_by')) {
+                $table->dropForeign('transfers_return_dispatched_by_foreign');
+                $table->dropIndex('transfers_return_dispatched_by_index');
+                $table->dropColumn(['return_dispatched_by', 'return_dispatched_at']);
+            }
+        });
+    }
+};

--- a/Modules/Adjustment/Database/Migrations/2025_09_23_120500_add_document_number_to_transfers_table.php
+++ b/Modules/Adjustment/Database/Migrations/2025_09_23_120500_add_document_number_to_transfers_table.php
@@ -1,0 +1,67 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('transfers', function (Blueprint $table) {
+            if (! Schema::hasColumn('transfers', 'document_number')) {
+                $table->string('document_number')->nullable()->after('id');
+            }
+        });
+
+        DB::transaction(function () {
+            $counters = [];
+
+            DB::table('transfers')
+                ->select(
+                    'transfers.id',
+                    'transfers.created_at',
+                    'transfers.origin_location_id',
+                    'locations.setting_id as origin_setting_id'
+                )
+                ->leftJoin('locations', 'locations.id', '=', 'transfers.origin_location_id')
+                ->orderBy('transfers.id')
+                ->chunkById(100, function ($rows) use (&$counters) {
+                    foreach ($rows as $row) {
+                        $timestamp = $row->created_at ? Carbon::parse($row->created_at) : now();
+                        $year      = $timestamp->format('Y');
+                        $month     = $timestamp->format('m');
+
+                        $settingKey = $row->origin_setting_id ?? ('origin:' . (int) $row->origin_location_id);
+                        $counterKey = sprintf('%s-%s-%s', $settingKey, $year, $month);
+
+                        $counters[$counterKey] = ($counters[$counterKey] ?? 0) + 1;
+
+                        $documentNumber = sprintf('TS-%s-%s-%04d', $year, $month, $counters[$counterKey]);
+
+                        DB::table('transfers')
+                            ->where('id', $row->id)
+                            ->update(['document_number' => $documentNumber]);
+                    }
+                }, 'transfers.id', 'transfers_id');
+        });
+
+        Schema::table('transfers', function (Blueprint $table) {
+            if (Schema::hasColumn('transfers', 'document_number')) {
+                $table->unique('document_number');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('transfers', function (Blueprint $table) {
+            if (Schema::hasColumn('transfers', 'document_number')) {
+                $table->dropUnique('transfers_document_number_unique');
+                $table->dropColumn('document_number');
+            }
+        });
+    }
+};

--- a/Modules/Adjustment/Database/Migrations/2025_09_23_120500_add_document_number_to_transfers_table.php
+++ b/Modules/Adjustment/Database/Migrations/2025_09_23_120500_add_document_number_to_transfers_table.php
@@ -45,7 +45,7 @@ return new class extends Migration
                             ->where('id', $row->id)
                             ->update(['document_number' => $documentNumber]);
                     }
-                }, 'transfers.id', 'transfers_id');
+                }, 'id');
         });
 
         Schema::table('transfers', function (Blueprint $table) {

--- a/Modules/Adjustment/Database/Migrations/2025_09_30_120000_adjust_transfer_document_number_unique.php
+++ b/Modules/Adjustment/Database/Migrations/2025_09_30_120000_adjust_transfer_document_number_unique.php
@@ -1,0 +1,114 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('transfers', 'document_number')) {
+            return;
+        }
+
+        if ($this->indexExists('transfers', 'transfers_document_number_unique')) {
+            Schema::table('transfers', function (Blueprint $table) {
+                $table->dropUnique('transfers_document_number_unique');
+            });
+        }
+
+        $this->deduplicatePerOriginAndPeriod();
+
+        if (! $this->indexExists('transfers', 'transfers_origin_document_number_unique')) {
+            Schema::table('transfers', function (Blueprint $table) {
+                $table->unique(['origin_location_id', 'document_number'], 'transfers_origin_document_number_unique');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasColumn('transfers', 'document_number')) {
+            return;
+        }
+
+        if ($this->indexExists('transfers', 'transfers_origin_document_number_unique')) {
+            Schema::table('transfers', function (Blueprint $table) {
+                $table->dropUnique('transfers_origin_document_number_unique');
+            });
+        }
+
+        if (! $this->indexExists('transfers', 'transfers_document_number_unique')) {
+            Schema::table('transfers', function (Blueprint $table) {
+                $table->unique('document_number');
+            });
+        }
+    }
+
+    private function deduplicatePerOriginAndPeriod(): void
+    {
+        $state = [];
+
+        DB::table('transfers')
+            ->select('id', 'origin_location_id', 'document_number')
+            ->whereNotNull('document_number')
+            ->orderBy('id')
+            ->chunkById(200, function ($rows) use (&$state) {
+                foreach ($rows as $row) {
+                    $documentNumber = $row->document_number;
+
+                    if (! preg_match('/^(TS-\d{4}-\d{2}-)(\d{4})$/', $documentNumber, $matches)) {
+                        continue;
+                    }
+
+                    $originKey = $row->origin_location_id ?? 'null';
+                    $prefix    = $matches[1];
+                    $sequence  = (int) $matches[2];
+                    $stateKey  = $originKey . '::' . $prefix;
+
+                    if (! array_key_exists($stateKey, $state)) {
+                        $state[$stateKey] = [
+                            'assigned' => [],
+                            'max'      => 0,
+                        ];
+                    }
+
+                    if (! in_array($sequence, $state[$stateKey]['assigned'], true)) {
+                        $state[$stateKey]['assigned'][] = $sequence;
+                        $state[$stateKey]['max']        = max($state[$stateKey]['max'], $sequence);
+                        continue;
+                    }
+
+                    $next = $state[$stateKey]['max'];
+
+                    do {
+                        $next++;
+                    } while (in_array($next, $state[$stateKey]['assigned'], true));
+
+                    $state[$stateKey]['assigned'][] = $next;
+                    $state[$stateKey]['max']        = max($state[$stateKey]['max'], $next);
+
+                    $nextDocumentNumber = $prefix . str_pad((string) $next, 4, '0', STR_PAD_LEFT);
+
+                    DB::table('transfers')
+                        ->where('id', $row->id)
+                        ->update(['document_number' => $nextDocumentNumber]);
+                }
+            }, 'id');
+    }
+
+    private function indexExists(string $table, string $index): bool
+    {
+        $connection = Schema::getConnection();
+        $database   = $connection->getDatabaseName();
+        $prefix     = $connection->getTablePrefix();
+
+        return DB::table('information_schema.statistics')
+            ->where('table_schema', $database)
+            ->where('table_name', $prefix . $table)
+            ->where('index_name', $index)
+            ->exists();
+    }
+};

--- a/Modules/Adjustment/Entities/Transfer.php
+++ b/Modules/Adjustment/Entities/Transfer.php
@@ -10,6 +10,14 @@ use Modules\Setting\Entities\Location;
 
 class Transfer extends BaseModel
 {
+    public const STATUS_PENDING           = 'PENDING';
+    public const STATUS_APPROVED          = 'APPROVED';
+    public const STATUS_REJECTED          = 'REJECTED';
+    public const STATUS_DISPATCHED        = 'DISPATCHED';
+    public const STATUS_RECEIVED          = 'RECEIVED';
+    public const STATUS_RETURN_DISPATCHED = 'RETURN_DISPATCHED';
+    public const STATUS_RETURN_RECEIVED   = 'RETURN_RECEIVED';
+
     protected $fillable = [
         'origin_location_id',
         'destination_location_id',
@@ -18,19 +26,25 @@ class Transfer extends BaseModel
         'rejected_by',
         'dispatched_by',
         'received_by',
+        'return_dispatched_by',
+        'return_received_by',
         'status',
         'transfer_date',
         'approved_at',
         'rejected_at',
         'dispatched_at',
         'received_at',
+        'return_dispatched_at',
+        'return_received_at',
     ];
 
     protected $casts = [
-        'approved_at' => 'datetime',
-        'rejected_at' => 'datetime',
-        'dispatched_at' => 'datetime',
-        'received_at' => 'datetime',
+        'approved_at'          => 'datetime',
+        'rejected_at'          => 'datetime',
+        'dispatched_at'        => 'datetime',
+        'received_at'          => 'datetime',
+        'return_dispatched_at' => 'datetime',
+        'return_received_at'   => 'datetime',
     ];
 
     /**
@@ -62,6 +76,16 @@ class Transfer extends BaseModel
         return $this->belongsTo(User::class, 'received_by');
     }
 
+    public function returnDispatchedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'return_dispatched_by');
+    }
+
+    public function returnReceivedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'return_received_by');
+    }
+
     public function originLocation(): BelongsTo
     {
         return $this->belongsTo(Location::class, 'origin_location_id');
@@ -75,5 +99,17 @@ class Transfer extends BaseModel
     public function products(): HasMany
     {
         return $this->hasMany(TransferProduct::class);
+    }
+
+    public function requiresReturn(): bool
+    {
+        $origin      = $this->relationLoaded('originLocation') ? $this->originLocation : $this->originLocation()->first();
+        $destination = $this->relationLoaded('destinationLocation') ? $this->destinationLocation : $this->destinationLocation()->first();
+
+        if (! $origin || ! $destination) {
+            return false;
+        }
+
+        return (int) $origin->setting_id !== (int) $destination->setting_id;
     }
 }

--- a/Modules/Adjustment/Entities/Transfer.php
+++ b/Modules/Adjustment/Entities/Transfer.php
@@ -6,7 +6,10 @@ use App\Models\BaseModel;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 use Modules\Setting\Entities\Location;
+use RuntimeException;
 
 class Transfer extends BaseModel
 {
@@ -19,6 +22,7 @@ class Transfer extends BaseModel
     public const STATUS_RETURN_RECEIVED   = 'RETURN_RECEIVED';
 
     protected $fillable = [
+        'document_number',
         'origin_location_id',
         'destination_location_id',
         'created_by',
@@ -39,6 +43,7 @@ class Transfer extends BaseModel
     ];
 
     protected $casts = [
+        'document_number'       => 'string',
         'approved_at'          => 'datetime',
         'rejected_at'          => 'datetime',
         'dispatched_at'        => 'datetime',
@@ -46,6 +51,96 @@ class Transfer extends BaseModel
         'return_dispatched_at' => 'datetime',
         'return_received_at'   => 'datetime',
     ];
+
+    protected static function booted(): void
+    {
+        static::creating(function (Transfer $transfer): void {
+            if ($transfer->document_number) {
+                return;
+            }
+
+            $transfer->document_number = static::nextDocumentNumber($transfer);
+        });
+    }
+
+    protected static function nextDocumentNumber(Transfer $transfer): string
+    {
+        $originLocationId = $transfer->origin_location_id;
+
+        if (! $originLocationId) {
+            throw new RuntimeException('Origin location is required to generate a document number.');
+        }
+
+        $settingId = null;
+
+        if ($transfer->relationLoaded('originLocation')) {
+            $settingId = $transfer->originLocation?->setting?->getKey();
+        }
+
+        if ($settingId === null) {
+            $settingId = Location::query()
+                ->whereKey($originLocationId)
+                ->value('setting_id');
+        }
+
+        $sequenceDate = static::resolveSequenceDate($transfer);
+
+        $year   = $sequenceDate->format('Y');
+        $month  = $sequenceDate->format('m');
+        $prefix = sprintf('TS-%s-%s-', $year, $month);
+
+        $resolver = function () use ($settingId, $transfer, $prefix) {
+            $query = DB::table('transfers')
+                ->leftJoin('locations', 'locations.id', '=', 'transfers.origin_location_id')
+                ->select('transfers.document_number')
+                ->whereNotNull('transfers.document_number')
+                ->where('transfers.document_number', 'like', $prefix . '%')
+                ->orderByDesc('transfers.document_number')
+                ->lockForUpdate();
+
+            $query->where(function ($builder) use ($settingId, $transfer) {
+                if ($settingId !== null) {
+                    $builder->where('locations.setting_id', $settingId);
+                } else {
+                    $builder->whereNull('locations.setting_id')
+                        ->where('transfers.origin_location_id', $transfer->origin_location_id);
+                }
+            });
+
+            $latest = $query->first();
+
+            $nextNumber = 1;
+
+            if ($latest && preg_match('/(\d{4})$/', $latest->document_number, $matches)) {
+                $nextNumber = (int) $matches[1] + 1;
+            }
+
+            return sprintf('%s%04d', $prefix, $nextNumber);
+        };
+
+        return DB::transactionLevel() > 0
+            ? $resolver()
+            : DB::transaction($resolver);
+    }
+
+    protected static function resolveSequenceDate(Transfer $transfer): Carbon
+    {
+        $value = $transfer->transfer_date ?? null;
+
+        if ($value instanceof Carbon) {
+            return $value->copy();
+        }
+
+        if ($value) {
+            try {
+                return Carbon::parse($value);
+            } catch (\Throwable $throwable) {
+                // fall through to now()
+            }
+        }
+
+        return Carbon::now();
+    }
 
     /**
      * Relationships

--- a/Modules/Adjustment/Entities/Transfer.php
+++ b/Modules/Adjustment/Entities/Transfer.php
@@ -63,6 +63,15 @@ class Transfer extends BaseModel
         });
     }
 
+    /**
+     * Generate the next document number for the given transfer.
+     *
+     * The database enforces uniqueness by combining the origin location ID with
+     * the document number, while this resolver still scopes its lookup by
+     * tenant/setting when available. That means different origins (or tenants)
+     * can legitimately reuse the same sequence value without collisions, but a
+     * single origin will never receive the same document number twice.
+     */
     protected static function nextDocumentNumber(Transfer $transfer): string
     {
         $originLocationId = $transfer->origin_location_id;

--- a/Modules/Adjustment/Http/Controllers/TransferStockController.php
+++ b/Modules/Adjustment/Http/Controllers/TransferStockController.php
@@ -126,6 +126,17 @@ class TransferStockController extends Controller
     {
         abort_unless(Gate::any(['stockTransfers.edit', 'stockTransfers.approval']), 403);
 
+        $transfer->loadMissing('originLocation.setting');
+
+        $currentSettingId = (int) session('setting_id');
+        $originSettingId  = $transfer->originLocation?->setting?->id;
+
+        if ($originSettingId === null || $currentSettingId !== (int) $originSettingId) {
+            toast('Transfer hanya dapat disetujui oleh tenant asal.', 'error');
+
+            return redirect()->route('transfers.show', $transfer->id);
+        }
+
         if ($transfer->status !== Transfer::STATUS_PENDING) {
             toast('Transfer tidak dapat disetujui pada status saat ini.', 'error');
 
@@ -149,6 +160,17 @@ class TransferStockController extends Controller
     public function reject(Transfer $transfer): RedirectResponse
     {
         abort_unless(Gate::any(['stockTransfers.edit', 'stockTransfers.approval']), 403);
+
+        $transfer->loadMissing('originLocation.setting');
+
+        $currentSettingId = (int) session('setting_id');
+        $originSettingId  = $transfer->originLocation?->setting?->id;
+
+        if ($originSettingId === null || $currentSettingId !== (int) $originSettingId) {
+            toast('Transfer hanya dapat ditolak oleh tenant asal.', 'error');
+
+            return redirect()->route('transfers.show', $transfer->id);
+        }
 
         if ($transfer->status !== Transfer::STATUS_PENDING) {
             toast('Transfer tidak dapat ditolak pada status saat ini.', 'error');

--- a/Modules/Adjustment/Http/Controllers/TransferStockController.php
+++ b/Modules/Adjustment/Http/Controllers/TransferStockController.php
@@ -42,7 +42,7 @@ class TransferStockController extends Controller
     {
         abort_if(Gate::denies('stockTransfers.create'), 403);
 
-        $currentSettingId = session('setting_id');
+        $currentSettingId = (int) session('setting_id');
         $currentSetting   = Setting::find($currentSettingId);
         $settings         = Setting::all();
         $locations        = Location::where('setting_id', $currentSettingId)->get();
@@ -102,10 +102,13 @@ class TransferStockController extends Controller
             'returnReceivedBy',
         ]);
 
-        $currentSettingId = session('setting_id');
+        $currentSettingId = (int) session('setting_id');
 
-        $isOrigin      = $transfer->originLocation && $currentSettingId === $transfer->originLocation->setting->id;
-        $isDestination = $transfer->destinationLocation && $currentSettingId === $transfer->destinationLocation->setting->id;
+        $originSettingId      = $transfer->originLocation?->setting?->id;
+        $destinationSettingId = $transfer->destinationLocation?->setting?->id;
+
+        $isOrigin      = $originSettingId !== null && $currentSettingId === (int) $originSettingId;
+        $isDestination = $destinationSettingId !== null && $currentSettingId === (int) $destinationSettingId;
         $requiresReturn = $transfer->requiresReturn();
 
         return view('adjustment::transfers.show', compact(

--- a/Modules/Adjustment/Http/Controllers/TransferStockController.php
+++ b/Modules/Adjustment/Http/Controllers/TransferStockController.php
@@ -79,7 +79,7 @@ class TransferStockController extends Controller
             ]);
         }
 
-        toast('Transfer Stok Dibuat!', 'success');
+        toast('Transfer Stok Dibuat! No. Dokumen: ' . $transfer->document_number, 'success');
 
         return redirect()->route('transfers.index');
     }
@@ -151,7 +151,7 @@ class TransferStockController extends Controller
             'approved_at' => Carbon::now(),
         ]);
 
-        toast('Transfer Stok Disetujui!', 'success');
+        toast('Transfer Stok Disetujui! No. Dokumen: ' . $transfer->document_number, 'success');
 
         return redirect()->route('transfers.show', $transfer->id);
     }
@@ -186,7 +186,7 @@ class TransferStockController extends Controller
             'rejected_at' => Carbon::now(),
         ]);
 
-        toast('Transfer Stok Ditolak!', 'warning');
+        toast('Transfer Stok Ditolak! No. Dokumen: ' . $transfer->document_number, 'warning');
 
         return redirect()->route('transfers.show', $transfer->id);
     }
@@ -274,7 +274,7 @@ class TransferStockController extends Controller
                 ]);
             });
 
-            toast('Transfer Stok Dikirim!', 'info');
+            toast('Transfer Stok Dikirim! No. Dokumen: ' . $transfer->document_number, 'info');
         } catch (Throwable $e) {
             Log::error('Failed to dispatch transfer', [
                 'transfer_id' => $transfer->id,
@@ -348,7 +348,7 @@ class TransferStockController extends Controller
                 ]);
             });
 
-            toast('Transfer Stok Diterima!', 'info');
+            toast('Transfer Stok Diterima! No. Dokumen: ' . $transfer->document_number, 'info');
         } catch (Throwable $e) {
             Log::error('Failed to receive transfer', [
                 'transfer_id' => $transfer->id,
@@ -438,7 +438,7 @@ class TransferStockController extends Controller
                 ]);
             });
 
-            toast('Barang dikirim kembali ke lokasi asal!', 'info');
+            toast('Barang dikirim kembali ke lokasi asal! No. Dokumen: ' . $transfer->document_number, 'info');
         } catch (Throwable $e) {
             Log::error('Failed to dispatch transfer return', [
                 'transfer_id' => $transfer->id,
@@ -512,7 +512,7 @@ class TransferStockController extends Controller
                 ]);
             });
 
-            toast('Barang kembali diterima di lokasi asal!', 'success');
+            toast('Barang kembali diterima di lokasi asal! No. Dokumen: ' . $transfer->document_number, 'success');
         } catch (Throwable $e) {
             Log::error('Failed to receive transfer return', [
                 'transfer_id' => $transfer->id,
@@ -563,7 +563,7 @@ class TransferStockController extends Controller
             ]);
         }
 
-        toast('Stock Transfer Updated!', 'success');
+        toast('Stock Transfer Updated! No. Dokumen: ' . $transfer->document_number, 'success');
 
         return redirect()->route('transfers.show', $transfer->id);
     }
@@ -581,7 +581,7 @@ class TransferStockController extends Controller
 
         $transfer->delete();
 
-        toast('Transfer Stok Dihapus!', 'warning');
+        toast('Transfer Stok Dihapus! No. Dokumen: ' . $transfer->document_number, 'warning');
 
         return redirect()->route('transfers.index');
     }

--- a/Modules/Adjustment/Resources/views/transfers/edit.blade.php
+++ b/Modules/Adjustment/Resources/views/transfers/edit.blade.php
@@ -23,6 +23,12 @@
                             @csrf
                             @method('PUT')
 
+                            <div class="form-group">
+                                <label for="document_number">Nomor Dokumen</label>
+                                <input id="document_number" type="text" class="form-control"
+                                       value="{{ $transfer->document_number }}" readonly>
+                            </div>
+
                             <!-- Step 1: Display Origin Business, Origin Location, and Destination Location as read-only -->
                             <div class="form-row">
                                 <!-- Origin Business (Read-Only) -->

--- a/Modules/Adjustment/Resources/views/transfers/show.blade.php
+++ b/Modules/Adjustment/Resources/views/transfers/show.blade.php
@@ -140,8 +140,8 @@
                         </table>
 
                         <div class="mt-4">
-                            {{-- Approve/Reject: only DESTINATION on PENDING --}}
-                            @if($transfer->status === Transfer::STATUS_PENDING && $isDestination)
+                            {{-- Approve/Reject: only ORIGIN on PENDING --}}
+                            @if($transfer->status === Transfer::STATUS_PENDING && $isOrigin)
                                 @canany(['stockTransfers.edit','stockTransfers.approval'])
                                     <form action="{{ route('transfers.approve', $transfer) }}" method="POST"
                                           class="d-inline">

--- a/Modules/Adjustment/Resources/views/transfers/show.blade.php
+++ b/Modules/Adjustment/Resources/views/transfers/show.blade.php
@@ -1,3 +1,4 @@
+@php use Modules\Adjustment\Entities\Transfer; @endphp
 @extends('layouts.app')
 
 @section('title', 'Detail Pemindahan Barang')
@@ -54,7 +55,8 @@
                                     <th>Disetujui Oleh</th>
                                     <td>
                                         {{ $transfer->approvedBy->name }}<br>
-                                        <small class="text-muted">{{ optional($transfer->approved_at)->format('Y-m-d H:i:s') }}</small>
+                                        <small
+                                            class="text-muted">{{ optional($transfer->approved_at)->format('Y-m-d H:i:s') }}</small>
                                     </td>
                                 </tr>
                             @endif
@@ -63,7 +65,8 @@
                                     <th>Dikirim Oleh</th>
                                     <td>
                                         {{ $transfer->dispatchedBy->name }}<br>
-                                        <small class="text-muted">{{ optional($transfer->dispatched_at)->format('Y-m-d H:i:s') }}</small>
+                                        <small
+                                            class="text-muted">{{ optional($transfer->dispatched_at)->format('Y-m-d H:i:s') }}</small>
                                     </td>
                                 </tr>
                             @endif
@@ -72,7 +75,8 @@
                                     <th>Diterima Oleh</th>
                                     <td>
                                         {{ $transfer->receivedBy->name }}<br>
-                                        <small class="text-muted">{{ optional($transfer->received_at)->format('Y-m-d H:i:s') }}</small>
+                                        <small
+                                            class="text-muted">{{ optional($transfer->received_at)->format('Y-m-d H:i:s') }}</small>
                                     </td>
                                 </tr>
                             @endif
@@ -81,7 +85,8 @@
                                     <th>Dikirim Kembali Oleh</th>
                                     <td>
                                         {{ $transfer->returnDispatchedBy->name }}<br>
-                                        <small class="text-muted">{{ optional($transfer->return_dispatched_at)->format('Y-m-d H:i:s') }}</small>
+                                        <small
+                                            class="text-muted">{{ optional($transfer->return_dispatched_at)->format('Y-m-d H:i:s') }}</small>
                                     </td>
                                 </tr>
                             @endif
@@ -90,7 +95,8 @@
                                     <th>Diterima Kembali Oleh</th>
                                     <td>
                                         {{ $transfer->returnReceivedBy->name }}<br>
-                                        <small class="text-muted">{{ optional($transfer->return_received_at)->format('Y-m-d H:i:s') }}</small>
+                                        <small
+                                            class="text-muted">{{ optional($transfer->return_received_at)->format('Y-m-d H:i:s') }}</small>
                                     </td>
                                 </tr>
                             @endif
@@ -135,45 +141,51 @@
 
                         <div class="mt-4">
                             {{-- Approve/Reject: only DESTINATION on PENDING --}}
-                            @if($transfer->status === \Modules\Adjustment\Entities\Transfer::STATUS_PENDING && $isDestination)
+                            @if($transfer->status === Transfer::STATUS_PENDING && $isDestination)
                                 @canany(['stockTransfers.edit','stockTransfers.approval'])
-                                    <form action="{{ route('transfers.approve', $transfer) }}" method="POST" class="d-inline">
+                                    <form action="{{ route('transfers.approve', $transfer) }}" method="POST"
+                                          class="d-inline">
                                         @csrf
                                         <button class="btn btn-success">Setujui</button>
                                     </form>
-                                    <form action="{{ route('transfers.reject', $transfer) }}" method="POST" class="d-inline">
+                                    <form action="{{ route('transfers.reject', $transfer) }}" method="POST"
+                                          class="d-inline">
                                         @csrf
                                         <button class="btn btn-danger">Tolak</button>
                                     </form>
                                 @endcanany
 
                                 {{-- Dispatch: only ORIGIN on APPROVED --}}
-                            @elseif($transfer->status === \Modules\Adjustment\Entities\Transfer::STATUS_APPROVED && $isOrigin)
+                            @elseif($transfer->status === Transfer::STATUS_APPROVED && $isOrigin)
                                 @can('stockTransfers.dispatch')
-                                    <form action="{{ route('transfers.dispatch', $transfer) }}" method="POST" class="d-inline">
+                                    <form action="{{ route('transfers.dispatch', $transfer) }}" method="POST"
+                                          class="d-inline">
                                         @csrf
                                         <button class="btn btn-primary">Keluarkan</button>
                                     </form>
                                 @endcan
 
                                 {{-- Receive: only DESTINATION on DISPATCHED --}}
-                            @elseif($transfer->status === \Modules\Adjustment\Entities\Transfer::STATUS_DISPATCHED && $isDestination)
+                            @elseif($transfer->status === Transfer::STATUS_DISPATCHED && $isDestination)
                                 @can('stockTransfers.receive')
-                                    <form action="{{ route('transfers.receive', $transfer) }}" method="POST" class="d-inline">
+                                    <form action="{{ route('transfers.receive', $transfer) }}" method="POST"
+                                          class="d-inline">
                                         @csrf
                                         <button class="btn btn-success">Terima</button>
                                     </form>
                                 @endcan
-                            @elseif($transfer->status === \Modules\Adjustment\Entities\Transfer::STATUS_RECEIVED && $requiresReturn && $isDestination)
+                            @elseif($transfer->status === Transfer::STATUS_RECEIVED && $requiresReturn && $isDestination)
                                 @can('stockTransfers.dispatch')
-                                    <form action="{{ route('transfers.return-dispatch', $transfer) }}" method="POST" class="d-inline">
+                                    <form action="{{ route('transfers.return-dispatch', $transfer) }}" method="POST"
+                                          class="d-inline">
                                         @csrf
                                         <button class="btn btn-warning">Kirim Kembali</button>
                                     </form>
                                 @endcan
-                            @elseif($transfer->status === \Modules\Adjustment\Entities\Transfer::STATUS_RETURN_DISPATCHED && $isOrigin)
+                            @elseif($transfer->status === Transfer::STATUS_RETURN_DISPATCHED && $isOrigin)
                                 @can('stockTransfers.receive')
-                                    <form action="{{ route('transfers.return-receive', $transfer) }}" method="POST" class="d-inline">
+                                    <form action="{{ route('transfers.return-receive', $transfer) }}" method="POST"
+                                          class="d-inline">
                                         @csrf
                                         <button class="btn btn-success">Terima Kembali</button>
                                     </form>

--- a/Modules/Adjustment/Resources/views/transfers/show.blade.php
+++ b/Modules/Adjustment/Resources/views/transfers/show.blade.php
@@ -41,8 +41,13 @@
                                 <th>Status Saat Ini</th>
                                 <td>
                                     <span class="badge badge-info">{{ str_replace('_', ' ', $transfer->status) }}</span>
-                                    @if($requiresReturn)
-                                        <span class="badge badge-warning ml-2">Butuh Pengembalian</span>
+                                    @if($transfer->status === Transfer::STATUS_RETURN_RECEIVED && $isOrigin && $requiresReturn)
+                                        <span class="badge badge-success">Barang Sudah Dikembalikan</span>
+                                    @else
+                                        <span class="badge badge-info">{{ str_replace('_', ' ', $transfer->status) }}</span>
+                                        @if($requiresReturn && $transfer->status !== Transfer::STATUS_RETURN_RECEIVED)
+                                            <span class="badge badge-warning ml-2">Butuh Pengembalian</span>
+                                        @endif
                                     @endif
                                 </td>
                             </tr>

--- a/Modules/Adjustment/Resources/views/transfers/show.blade.php
+++ b/Modules/Adjustment/Resources/views/transfers/show.blade.php
@@ -19,47 +19,79 @@
                         <h5 class="card-title">Informasi Pemindahan Stok</h5>
                         <table class="table table-bordered mb-4">
                             <tr>
-                                <th>Tanggal:</th>
-                                <td>{{ $transfer->created_at->format('Y-m-d H:i:s') }}</td>
+                                <th>Tanggal Dokumen</th>
+                                <td>{{ optional($transfer->created_at)->format('Y-m-d H:i:s') ?? '-' }}</td>
                             </tr>
                             <tr>
-                                <th>Lokasi Asal:</th>
+                                <th>Lokasi Asal</th>
                                 <td>
                                     {{ $transfer->originLocation->name ?? '-' }}<br>
                                     <small>{{ $transfer->originLocation->setting->company_name ?? '-' }}</small>
                                 </td>
                             </tr>
                             <tr>
-                                <th>Lokasi Tujuan:</th>
+                                <th>Lokasi Tujuan</th>
                                 <td>
                                     {{ $transfer->destinationLocation->name ?? '-' }}<br>
                                     <small>{{ $transfer->destinationLocation->setting->company_name ?? '-' }}</small>
                                 </td>
                             </tr>
                             <tr>
-                                <th>Status:</th>
-                                <td>{{ strtoupper($transfer->status) }}</td>
+                                <th>Status Saat Ini</th>
+                                <td>
+                                    <span class="badge badge-info">{{ str_replace('_', ' ', $transfer->status) }}</span>
+                                    @if($requiresReturn)
+                                        <span class="badge badge-warning ml-2">Butuh Pengembalian</span>
+                                    @endif
+                                </td>
                             </tr>
                             <tr>
-                                <th>Dibuat Oleh:</th>
+                                <th>Dibuat Oleh</th>
                                 <td>{{ $transfer->createdBy->name ?? '-' }}</td>
                             </tr>
-                            @if($transfer->approver)
+                            @if($transfer->approvedBy)
                                 <tr>
-                                    <th>Disetujui Oleh:</th>
-                                    <td>{{ $transfer->approver->name }}</td>
+                                    <th>Disetujui Oleh</th>
+                                    <td>
+                                        {{ $transfer->approvedBy->name }}<br>
+                                        <small class="text-muted">{{ optional($transfer->approved_at)->format('Y-m-d H:i:s') }}</small>
+                                    </td>
                                 </tr>
                             @endif
-                            @if($transfer->dispatcher)
+                            @if($transfer->dispatchedBy)
                                 <tr>
-                                    <th>Dikeluarkan Oleh:</th>
-                                    <td>{{ $transfer->dispatcher->name }}</td>
+                                    <th>Dikirim Oleh</th>
+                                    <td>
+                                        {{ $transfer->dispatchedBy->name }}<br>
+                                        <small class="text-muted">{{ optional($transfer->dispatched_at)->format('Y-m-d H:i:s') }}</small>
+                                    </td>
                                 </tr>
                             @endif
-                            @if($transfer->receiver)
+                            @if($transfer->receivedBy)
                                 <tr>
-                                    <th>Diterima Oleh:</th>
-                                    <td>{{ $transfer->receiver->name }}</td>
+                                    <th>Diterima Oleh</th>
+                                    <td>
+                                        {{ $transfer->receivedBy->name }}<br>
+                                        <small class="text-muted">{{ optional($transfer->received_at)->format('Y-m-d H:i:s') }}</small>
+                                    </td>
+                                </tr>
+                            @endif
+                            @if($transfer->returnDispatchedBy)
+                                <tr>
+                                    <th>Dikirim Kembali Oleh</th>
+                                    <td>
+                                        {{ $transfer->returnDispatchedBy->name }}<br>
+                                        <small class="text-muted">{{ optional($transfer->return_dispatched_at)->format('Y-m-d H:i:s') }}</small>
+                                    </td>
+                                </tr>
+                            @endif
+                            @if($transfer->returnReceivedBy)
+                                <tr>
+                                    <th>Diterima Kembali Oleh</th>
+                                    <td>
+                                        {{ $transfer->returnReceivedBy->name }}<br>
+                                        <small class="text-muted">{{ optional($transfer->return_received_at)->format('Y-m-d H:i:s') }}</small>
+                                    </td>
                                 </tr>
                             @endif
                         </table>
@@ -103,7 +135,7 @@
 
                         <div class="mt-4">
                             {{-- Approve/Reject: only DESTINATION on PENDING --}}
-                            @if($transfer->status === 'PENDING' && $isDestination)
+                            @if($transfer->status === \Modules\Adjustment\Entities\Transfer::STATUS_PENDING && $isDestination)
                                 @canany(['stockTransfers.edit','stockTransfers.approval'])
                                     <form action="{{ route('transfers.approve', $transfer) }}" method="POST" class="d-inline">
                                         @csrf
@@ -116,7 +148,7 @@
                                 @endcanany
 
                                 {{-- Dispatch: only ORIGIN on APPROVED --}}
-                            @elseif($transfer->status === 'APPROVED' && $isOrigin)
+                            @elseif($transfer->status === \Modules\Adjustment\Entities\Transfer::STATUS_APPROVED && $isOrigin)
                                 @can('stockTransfers.dispatch')
                                     <form action="{{ route('transfers.dispatch', $transfer) }}" method="POST" class="d-inline">
                                         @csrf
@@ -125,11 +157,25 @@
                                 @endcan
 
                                 {{-- Receive: only DESTINATION on DISPATCHED --}}
-                            @elseif($transfer->status === 'DISPATCHED' && $isDestination)
+                            @elseif($transfer->status === \Modules\Adjustment\Entities\Transfer::STATUS_DISPATCHED && $isDestination)
                                 @can('stockTransfers.receive')
                                     <form action="{{ route('transfers.receive', $transfer) }}" method="POST" class="d-inline">
                                         @csrf
                                         <button class="btn btn-success">Terima</button>
+                                    </form>
+                                @endcan
+                            @elseif($transfer->status === \Modules\Adjustment\Entities\Transfer::STATUS_RECEIVED && $requiresReturn && $isDestination)
+                                @can('stockTransfers.dispatch')
+                                    <form action="{{ route('transfers.return-dispatch', $transfer) }}" method="POST" class="d-inline">
+                                        @csrf
+                                        <button class="btn btn-warning">Kirim Kembali</button>
+                                    </form>
+                                @endcan
+                            @elseif($transfer->status === \Modules\Adjustment\Entities\Transfer::STATUS_RETURN_DISPATCHED && $isOrigin)
+                                @can('stockTransfers.receive')
+                                    <form action="{{ route('transfers.return-receive', $transfer) }}" method="POST" class="d-inline">
+                                        @csrf
+                                        <button class="btn btn-success">Terima Kembali</button>
                                     </form>
                                 @endcan
                             @endif

--- a/Modules/Adjustment/Resources/views/transfers/show.blade.php
+++ b/Modules/Adjustment/Resources/views/transfers/show.blade.php
@@ -20,6 +20,10 @@
                         <h5 class="card-title">Informasi Pemindahan Stok</h5>
                         <table class="table table-bordered mb-4">
                             <tr>
+                                <th>Nomor Dokumen</th>
+                                <td>{{ $transfer->document_number ?? '-' }}</td>
+                            </tr>
+                            <tr>
                                 <th>Tanggal Dokumen</th>
                                 <td>{{ optional($transfer->created_at)->format('Y-m-d H:i:s') ?? '-' }}</td>
                             </tr>

--- a/Modules/Adjustment/Routes/web.php
+++ b/Modules/Adjustment/Routes/web.php
@@ -27,5 +27,7 @@ Route::group(['middleware' => ['auth', 'role.setting']], function () {
     Route::post('/transfers/{transfer}/reject', 'TransferStockController@reject')->name('transfers.reject');
     Route::post('/transfers/{transfer}/dispatch', 'TransferStockController@dispatchShipment')->name('transfers.dispatch');
     Route::post('/transfers/{transfer}/receive', 'TransferStockController@receive')->name('transfers.receive');
+    Route::post('/transfers/{transfer}/return-dispatch', 'TransferStockController@dispatchReturn')->name('transfers.return-dispatch');
+    Route::post('/transfers/{transfer}/return-receive', 'TransferStockController@receiveReturn')->name('transfers.return-receive');
     Route::resource('transfers', 'TransferStockController');
 });

--- a/Modules/Setting/Http/Controllers/BusinessController.php
+++ b/Modules/Setting/Http/Controllers/BusinessController.php
@@ -170,7 +170,7 @@ class BusinessController extends Controller
 
     public function updateActiveBusiness(Request $request): RedirectResponse
     {
-        $settingId = $request->input('setting_id');
+        $settingId = (int) $request->input('setting_id');
 
         // Update the session with the new setting ID
         $request->session()->put('setting_id', $settingId);

--- a/app/Livewire/AutoComplete/SerialNumberLoader.php
+++ b/app/Livewire/AutoComplete/SerialNumberLoader.php
@@ -64,6 +64,10 @@ class SerialNumberLoader extends Component
             ]);
 
             $baseQuery = ProductSerialNumber::where('serial_number', 'like', '%' . $this->query . '%')
+                ->when(
+                    $this->location_id,
+                    fn($query) => $query->where('location_id', $this->location_id)
+                )
                 ->when($this->product_id > 0, fn($query) => $query->where('product_id', $this->product_id))
                 ->when($this->is_taxed,
                     fn($query) => $query->whereNotNull('tax_id')->where('tax_id', '>', 0),
@@ -84,7 +88,14 @@ class SerialNumberLoader extends Component
 
     public function selectSerialNumber($serialNumberId): void
     {
-        $serialNumber = ProductSerialNumber::find($serialNumberId);
+        $serialNumber = ProductSerialNumber::query()
+            ->whereKey($serialNumberId)
+            ->when(
+                $this->location_id,
+                fn($query) => $query->where('location_id', $this->location_id)
+            )
+            ->first();
+
         if ($serialNumber) {
             $this->search_results = [$serialNumber];
             $this->query = "$serialNumber->serial_number";

--- a/app/Livewire/AutoComplete/SerialNumberLoader.php
+++ b/app/Livewire/AutoComplete/SerialNumberLoader.php
@@ -75,7 +75,10 @@ class SerialNumberLoader extends Component
                         $q->whereNull('tax_id')->orWhere('tax_id', 0);
                     })
                 )
-                ->when($this->is_broken, fn($query) => $query->where('is_broken', true))
+                ->when(
+                    ! is_null($this->is_broken),
+                    fn($query) => $query->where('is_broken', (bool) $this->is_broken)
+                )
                 ->when($this->is_dispatch, fn($query) => $query->whereNull('dispatch_detail_id'));
 
             $this->query_count = $baseQuery->count();

--- a/app/Livewire/Transfer/TransferProductTable.php
+++ b/app/Livewire/Transfer/TransferProductTable.php
@@ -3,14 +3,16 @@
 namespace App\Livewire\Transfer;
 
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Log;
 use Livewire\Component;
+use Modules\Product\Entities\ProductSerialNumber;
 use Modules\Product\Entities\ProductStock;
 
 class TransferProductTable extends Component
 {
     protected $listeners = [
         'productSelected',
+        'serialNumberSelected',
+        'removeSerialNumber',
         'locationsConfirmed'      => 'resetOnNewLocations',
         'tableValidationErrors'   => 'onTableValidationErrors',
     ];
@@ -18,6 +20,7 @@ class TransferProductTable extends Component
     public $products = [];
     public $originLocationId;
     public $destinationLocationId;
+    public $serialNumberErrors = [];
 
     // holds validation errors for table rows
     public $tableValidationErrors = [];
@@ -30,6 +33,7 @@ class TransferProductTable extends Component
         $this->originLocationId      = $originLocationId;
         $this->destinationLocationId = $destinationLocationId;
         $this->products              = [];
+        $this->serialNumberErrors    = [];
     }
 
     /**
@@ -40,6 +44,7 @@ class TransferProductTable extends Component
         $this->originLocationId      = $payload['originLocationId'];
         $this->destinationLocationId = $payload['destinationLocationId'];
         $this->products              = [];
+        $this->serialNumberErrors    = [];
         $this->tableValidationErrors = [];
 
         // notify parent of reset
@@ -76,8 +81,11 @@ class TransferProductTable extends Component
         $product['quantity_non_tax']        = 0;
         $product['broken_quantity_tax']     = 0;
         $product['broken_quantity_non_tax'] = 0;
+        $product['serial_number_required']  = (bool) ($product['serial_number_required'] ?? false);
+        $product['serial_numbers']          = [];
 
         $this->products[] = $product;
+        $this->serialNumberErrors[] = null;
         $this->tableValidationErrors = [];
 
         // notify parent that rows have changed
@@ -91,10 +99,143 @@ class TransferProductTable extends Component
     {
         unset($this->products[$key]);
         $this->products = array_values($this->products);
+        unset($this->serialNumberErrors[$key]);
+        $this->serialNumberErrors = array_values($this->serialNumberErrors);
         $this->tableValidationErrors = [];
 
         // notify parent that rows have changed
         $this->dispatch('rowsUpdated', $this->products);
+    }
+
+    public function serialNumberSelected($payload): void
+    {
+        $productCompositeKey = $payload['productCompositeKey'] ?? null;
+
+        if (! is_numeric($productCompositeKey)) {
+            return;
+        }
+
+        $rowKey = (int) $productCompositeKey;
+
+        if (! isset($this->products[$rowKey])) {
+            return;
+        }
+
+        if (empty($this->products[$rowKey]['serial_number_required'])) {
+            return;
+        }
+
+        $serialNumber = $payload['serialNumber'] ?? null;
+        $serialId     = (int) ($serialNumber['id'] ?? 0);
+
+        if ($serialId <= 0) {
+            return;
+        }
+
+        // Prevent duplicate selections across all rows
+        if ($this->serialExistsInRows($serialId, $rowKey)) {
+            $this->serialNumberErrors[$rowKey] = 'Nomor seri sudah dipilih.';
+            return;
+        }
+
+        $serial = ProductSerialNumber::find($serialId);
+
+        if (! $serial) {
+            $this->serialNumberErrors[$rowKey] = 'Nomor seri tidak ditemukan.';
+            return;
+        }
+
+        $currentSerials = collect($this->products[$rowKey]['serial_numbers'] ?? []);
+
+        if ($currentSerials->pluck('id')->contains($serial->id)) {
+            $this->serialNumberErrors[$rowKey] = 'Nomor seri sudah dipilih.';
+            return;
+        }
+
+        $this->serialNumberErrors[$rowKey] = null;
+
+        $this->products[$rowKey]['serial_numbers'][] = [
+            'id'            => $serial->id,
+            'serial_number' => $serial->serial_number,
+            'tax_id'        => $serial->tax_id,
+            'taxable'       => (bool) $serial->tax_id,
+            'is_broken'     => (bool) $serial->is_broken,
+        ];
+
+        $this->recalculateSerialQuantities($rowKey);
+
+        $this->dispatch('rowsUpdated', $this->products);
+    }
+
+    public function removeSerialNumber($rowKey, $serialIndex = null): void
+    {
+        if (is_array($rowKey)) {
+            $serialIndex = $rowKey['serialIndex'] ?? null;
+            $rowKey      = $rowKey['productCompositeKey'] ?? $rowKey['row'] ?? null;
+        }
+
+        if (! is_numeric($rowKey)) {
+            return;
+        }
+
+        $rowKey = (int) $rowKey;
+
+        if (! isset($this->products[$rowKey]) || $serialIndex === null) {
+            return;
+        }
+
+        if (! isset($this->products[$rowKey]['serial_numbers'][$serialIndex])) {
+            return;
+        }
+
+        unset($this->products[$rowKey]['serial_numbers'][$serialIndex]);
+        $this->products[$rowKey]['serial_numbers'] = array_values($this->products[$rowKey]['serial_numbers']);
+
+        $this->serialNumberErrors[$rowKey] = null;
+
+        $this->recalculateSerialQuantities($rowKey);
+
+        $this->dispatch('rowsUpdated', $this->products);
+    }
+
+    protected function serialExistsInRows(int $serialId, int $currentRowKey): bool
+    {
+        return collect($this->products)
+            ->filter(fn ($_, $index) => $index !== $currentRowKey)
+            ->pluck('serial_numbers')
+            ->flatten(1)
+            ->pluck('id')
+            ->contains($serialId);
+    }
+
+    protected function recalculateSerialQuantities(int $rowKey): void
+    {
+        $serials = $this->products[$rowKey]['serial_numbers'] ?? [];
+
+        $quantityTax            = 0;
+        $quantityNonTax        = 0;
+        $brokenQuantityTax     = 0;
+        $brokenQuantityNonTax  = 0;
+
+        foreach ($serials as $serial) {
+            $isBroken = (bool) ($serial['is_broken'] ?? false);
+            $isTaxed  = (bool) ($serial['taxable'] ?? false);
+
+            if ($isBroken && $isTaxed) {
+                $brokenQuantityTax++;
+            } elseif ($isBroken && ! $isTaxed) {
+                $brokenQuantityNonTax++;
+            } elseif (! $isBroken && $isTaxed) {
+                $quantityTax++;
+            } else {
+                $quantityNonTax++;
+            }
+        }
+
+        $this->products[$rowKey]['quantity_tax']            = $quantityTax;
+        $this->products[$rowKey]['quantity_non_tax']        = $quantityNonTax;
+        $this->products[$rowKey]['broken_quantity_tax']     = $brokenQuantityTax;
+        $this->products[$rowKey]['broken_quantity_non_tax'] = $brokenQuantityNonTax;
     }
 
     /**

--- a/app/Livewire/Transfer/TransferProductTable.php
+++ b/app/Livewire/Transfer/TransferProductTable.php
@@ -69,11 +69,11 @@ class TransferProductTable extends Component
 
         // merge in all the relevant stock columns
         $product['stock'] = [
-            'total'                   => $stock->quantity                 ?? 0,
-            'quantity_tax'            => $stock->quantity_tax             ?? 0,
-            'quantity_non_tax'        => $stock->quantity_non_tax         ?? 0,
-            'broken_quantity_tax'     => $stock->broken_quantity_tax      ?? 0,
-            'broken_quantity_non_tax' => $stock->broken_quantity_non_tax  ?? 0,
+            'total'                   => $stock?->quantity                 ?? 0,
+            'quantity_tax'            => $stock?->quantity_tax             ?? 0,
+            'quantity_non_tax'        => $stock?->quantity_non_tax         ?? 0,
+            'broken_quantity_tax'     => $stock?->broken_quantity_tax      ?? 0,
+            'broken_quantity_non_tax' => $stock?->broken_quantity_non_tax  ?? 0,
         ];
 
         // initialize transfer inputs

--- a/app/Livewire/Transfer/TransferStockForm.php
+++ b/app/Livewire/Transfer/TransferStockForm.php
@@ -93,35 +93,69 @@ class TransferStockForm extends Component
         }
 
         // validate rows
+        $preparedRows = [];
+
         if (empty($this->rows)) {
             $this->selfManagedValidationErrors['rows'] = 'Silakan pilih minimal satu produk.';
         } else {
             foreach ($this->rows as $i => $row) {
-                $qt  = $row['quantity_tax']            ?? 0;
-                $qn  = $row['quantity_non_tax']        ?? 0;
-                $bqt = $row['broken_quantity_tax']     ?? 0;
-                $bqn = $row['broken_quantity_non_tax'] ?? 0;
-                $total = $qt + $qn + $bqt + $bqn;
+                $manualQuantities = [
+                    'quantity_tax'            => max(0, (int) ($row['quantity_tax']            ?? 0)),
+                    'quantity_non_tax'        => max(0, (int) ($row['quantity_non_tax']        ?? 0)),
+                    'quantity_broken_tax'     => max(0, (int) ($row['broken_quantity_tax']     ?? 0)),
+                    'quantity_broken_non_tax' => max(0, (int) ($row['broken_quantity_non_tax'] ?? 0)),
+                ];
+
+                $serials       = $this->normalizeSerialPayload($row['serial_numbers'] ?? []);
+                $serialDetails = $this->calculateSerialBreakdown($serials);
+
+                $finalQuantities = $manualQuantities;
+                $requiresSerial  = ! empty($row['serial_number_required']);
+
+                if (! empty($serials)) {
+                    if ($manualQuantities !== $serialDetails['quantities']) {
+                        $tableErrors["row.{$i}.serial_numbers"] =
+                            'Jumlah nomor seri tidak sesuai dengan rincian kuantitas yang dimasukkan.';
+                    }
+
+                    $finalQuantities = $serialDetails['quantities'];
+                }
+
+                if ($requiresSerial && empty($serials)) {
+                    $tableErrors["row.{$i}.serial_numbers"] = 'Produk ini memerlukan nomor seri.';
+                }
+
+                $total = array_sum($finalQuantities);
 
                 if ($total <= 0) {
                     $tableErrors["row.{$i}"] = "Jumlah keseluruhan produk harus lebih besar dari 0.";
                 }
-                if ($qt > ($row['stock']['quantity_tax'] ?? 0)) {
+
+                $stock = $row['stock'] ?? [];
+
+                if ($finalQuantities['quantity_tax'] > ($stock['quantity_tax'] ?? 0)) {
                     $tableErrors["row.{$i}.quantity_tax"] =
-                        "Jumlah Pajak tidak boleh lebih dari stok ({$row['stock']['quantity_tax']}).";
+                        "Jumlah Pajak tidak boleh lebih dari stok ({$stock['quantity_tax']}).";
                 }
-                if ($qn > ($row['stock']['quantity_non_tax'] ?? 0)) {
+                if ($finalQuantities['quantity_non_tax'] > ($stock['quantity_non_tax'] ?? 0)) {
                     $tableErrors["row.{$i}.quantity_non_tax"] =
-                        "Jumlah Non Pajak tidak boleh lebih dari stok ({$row['stock']['quantity_non_tax']}).";
+                        "Jumlah Non Pajak tidak boleh lebih dari stok ({$stock['quantity_non_tax']}).";
                 }
-                if ($bqt > ($row['stock']['broken_quantity_tax'] ?? 0)) {
+                if ($finalQuantities['quantity_broken_tax'] > ($stock['broken_quantity_tax'] ?? 0)) {
                     $tableErrors["row.{$i}.broken_quantity_tax"] =
-                        "Rusak Pajak tidak boleh lebih dari stok rusak ({$row['stock']['broken_quantity_tax']}).";
+                        "Rusak Pajak tidak boleh lebih dari stok rusak ({$stock['broken_quantity_tax']}).";
                 }
-                if ($bqn > ($row['stock']['broken_quantity_non_tax'] ?? 0)) {
+                if ($finalQuantities['quantity_broken_non_tax'] > ($stock['broken_quantity_non_tax'] ?? 0)) {
                     $tableErrors["row.{$i}.broken_quantity_non_tax"] =
-                        "Rusak Non Pajak tidak boleh lebih dari stok rusak ({$row['stock']['broken_quantity_non_tax']}).";
+                        "Rusak Non Pajak tidak boleh lebih dari stok rusak ({$stock['broken_quantity_non_tax']}).";
                 }
+
+                $preparedRows[] = [
+                    'id'                       => $row['id'],
+                    'serial_numbers'           => $serials,
+                    'quantities'               => $finalQuantities,
+                    'total'                    => $total,
+                ];
             }
         }
 
@@ -146,22 +180,17 @@ class TransferStockForm extends Component
             ]);
 
             // 2) create each transfer_product row
-            foreach ($this->rows as $row) {
-                $qt  = $row['quantity_tax']            ?? 0;
-                $qn  = $row['quantity_non_tax']        ?? 0;
-                $bqt = $row['broken_quantity_tax']     ?? 0;
-                $bqn = $row['broken_quantity_non_tax'] ?? 0;
-                $total = $qt + $qn + $bqt + $bqn;
-
+            foreach ($preparedRows as $row) {
+                $quantities = $row['quantities'];
                 TransferProduct::create([
                     'transfer_id'               => $transfer->id,
                     'product_id'                => $row['id'],
-                    'quantity'                  => $total,
-                    'quantity_tax'              => $qt,
-                    'quantity_non_tax'          => $qn,
-                    'quantity_broken_tax'       => $bqt,
-                    'quantity_broken_non_tax'   => $bqn,
-                    // serial_numbers left null here; will be filled at dispatch
+                    'quantity'                  => $row['total'],
+                    'quantity_tax'              => $quantities['quantity_tax'],
+                    'quantity_non_tax'          => $quantities['quantity_non_tax'],
+                    'quantity_broken_tax'       => $quantities['quantity_broken_tax'],
+                    'quantity_broken_non_tax'   => $quantities['quantity_broken_non_tax'],
+                    'serial_numbers'            => ! empty($row['serial_numbers']) ? $row['serial_numbers'] : null,
                 ]);
             }
 
@@ -190,5 +219,68 @@ class TransferStockForm extends Component
             'originLocationId'      => $this->originLocation,
             'destinationLocationId' => $this->destinationLocation,
         ]);
+    }
+
+    private function normalizeSerialPayload(array $serials): array
+    {
+        return collect($serials)
+            ->map(function ($serial) {
+                $id = (int) ($serial['id'] ?? 0);
+
+                if ($id <= 0) {
+                    return null;
+                }
+
+                $taxId   = $serial['tax_id'] ?? null;
+                $taxable = array_key_exists('taxable', $serial)
+                    ? (bool) $serial['taxable']
+                    : ! empty($taxId);
+
+                return [
+                    'id'            => $id,
+                    'serial_number' => $serial['serial_number'] ?? null,
+                    'tax_id'        => $taxId !== null ? (int) $taxId : null,
+                    'taxable'       => $taxable,
+                    'is_broken'     => (bool) ($serial['is_broken'] ?? false),
+                ];
+            })
+            ->filter()
+            ->values()
+            ->toArray();
+    }
+
+    private function calculateSerialBreakdown(array $serials): array
+    {
+        $quantityTax           = 0;
+        $quantityNonTax        = 0;
+        $brokenQuantityTax     = 0;
+        $brokenQuantityNonTax  = 0;
+
+        foreach ($serials as $serial) {
+            $isBroken = (bool) ($serial['is_broken'] ?? false);
+            $isTaxed  = array_key_exists('taxable', $serial)
+                ? (bool) $serial['taxable']
+                : ! empty($serial['tax_id']);
+
+            if ($isBroken && $isTaxed) {
+                $brokenQuantityTax++;
+            } elseif ($isBroken && ! $isTaxed) {
+                $brokenQuantityNonTax++;
+            } elseif ($isTaxed) {
+                $quantityTax++;
+            } else {
+                $quantityNonTax++;
+            }
+        }
+
+        return [
+            'quantities' => [
+                'quantity_tax'            => $quantityTax,
+                'quantity_non_tax'        => $quantityNonTax,
+                'quantity_broken_tax'     => $brokenQuantityTax,
+                'quantity_broken_non_tax' => $brokenQuantityNonTax,
+            ],
+            'total' => $quantityTax + $quantityNonTax + $brokenQuantityTax + $brokenQuantityNonTax,
+        ];
     }
 }

--- a/app/Livewire/Transfer/TransferStockForm.php
+++ b/app/Livewire/Transfer/TransferStockForm.php
@@ -197,7 +197,7 @@ class TransferStockForm extends Component
             DB::commit();
 
             // 3) reset form and show success
-            toast('Transfer Stok Dibuat!', 'success');
+            toast('Transfer Stok Dibuat! No. Dokumen: ' . $transfer->document_number, 'success');
             //
             return redirect()->route('transfers.index');
         }

--- a/resources/views/livewire/transfer/transfer-product-table.blade.php
+++ b/resources/views/livewire/transfer/transfer-product-table.blade.php
@@ -50,27 +50,91 @@
 
                     @php
                         $fields = [
-                            'quantity_tax'             => 'Jumlah Pajak',
-                            'quantity_non_tax'         => 'Jumlah Non Pajak',
-                            'broken_quantity_tax'      => 'Rusak Pajak',
-                            'broken_quantity_non_tax'  => 'Rusak Non Pajak',
+                            'quantity_tax'             => ['label' => 'Jumlah Pajak', 'is_taxed' => true,  'is_broken' => false],
+                            'quantity_non_tax'         => ['label' => 'Jumlah Non Pajak', 'is_taxed' => false, 'is_broken' => false],
+                            'broken_quantity_tax'      => ['label' => 'Rusak Pajak', 'is_taxed' => true,  'is_broken' => true],
+                            'broken_quantity_non_tax'  => ['label' => 'Rusak Non Pajak', 'is_taxed' => false, 'is_broken' => true],
                         ];
+                        $serialRequired = $p['serial_number_required'] ?? false;
+                        $serials = collect($p['serial_numbers'] ?? []);
                     @endphp
 
-                    @foreach($fields as $field => $label)
+                    @foreach($fields as $field => $config)
                         <td>
-                            <input
-                                type="number"
-                                min="0"
-                                class="form-control"
-                                wire:model.lazy="products.{{ $i }}.{{ $field }}"
-                            >
+                            @if($serialRequired)
+                                <div class="d-flex flex-column">
+                                    <div class="mb-2">
+                                        @if($originLocationId)
+                                            <livewire:auto-complete.serial-number-loader
+                                                :location-id="$originLocationId"
+                                                :product-id="$p['id']"
+                                                :is-taxed="$config['is_taxed']"
+                                                :is-broken="$config['is_broken']"
+                                                :serial-index="'transfer-' . $field . '-' . $i"
+                                                :product-composite-key="$i"
+                                                :is-dispatch="true"
+                                                wire:key="transfer-serial-{{ $field }}-{{ $i }}"
+                                            />
+                                        @else
+                                            <div class="alert alert-warning mb-2 py-1 px-2">
+                                                <small>Pilih lokasi asal terlebih dahulu.</small>
+                                            </div>
+                                        @endif
+                                    </div>
 
-                            {{-- field-level error --}}
-                            @if(isset($tableValidationErrors["row.{$i}.{$field}"]))
-                                <div class="text-danger small mt-1">
-                                    {{ $tableValidationErrors["row.{$i}.{$field}"] }}
+                                    <div class="form-control-plaintext text-center font-weight-bold">
+                                        {{ $p[$field] ?? 0 }}
+                                    </div>
+
+                                    @php
+                                        $filteredSerials = $serials->filter(function ($serial, $serialIndex) use ($config) {
+                                            $matchesTax   = (bool) ($serial['taxable'] ?? false) === (bool) $config['is_taxed'];
+                                            $matchesBroken = (bool) ($serial['is_broken'] ?? false) === (bool) $config['is_broken'];
+
+                                            return $matchesTax && $matchesBroken;
+                                        });
+                                    @endphp
+
+                                    <div class="mt-2">
+                                        @if($filteredSerials->isEmpty())
+                                            <small class="text-muted">Belum ada nomor seri.</small>
+                                        @else
+                                            <div class="d-flex flex-wrap">
+                                                @foreach($filteredSerials as $serialIndex => $serial)
+                                                    <span class="badge badge-light border d-flex align-items-center mb-1 mr-1">
+                                                        <span>{{ $serial['serial_number'] }}</span>
+                                                        <button type="button"
+                                                            class="btn btn-link btn-sm text-danger p-0 ml-2"
+                                                            wire:click="removeSerialNumber({{ $i }}, {{ $serialIndex }})"
+                                                            title="Hapus nomor seri">
+                                                            <i class="bi bi-x-circle"></i>
+                                                        </button>
+                                                    </span>
+                                                @endforeach
+                                            </div>
+                                        @endif
+                                    </div>
+
+                                    @if(isset($tableValidationErrors["row.{$i}.{$field}"]))
+                                        <div class="text-danger small mt-1">
+                                            {{ $tableValidationErrors["row.{$i}.{$field}"] }}
+                                        </div>
+                                    @endif
                                 </div>
+                            @else
+                                <input
+                                    type="number"
+                                    min="0"
+                                    class="form-control"
+                                    wire:model.lazy="products.{{ $i }}.{{ $field }}"
+                                >
+
+                                {{-- field-level error --}}
+                                @if(isset($tableValidationErrors["row.{$i}.{$field}"]))
+                                    <div class="text-danger small mt-1">
+                                        {{ $tableValidationErrors["row.{$i}.{$field}"] }}
+                                    </div>
+                                @endif
                             @endif
                         </td>
                     @endforeach
@@ -85,6 +149,13 @@
                         </button>
                     </td>
                 </tr>
+                @if(($p['serial_number_required'] ?? false) && !empty($serialNumberErrors[$i]))
+                    <tr>
+                        <td colspan="8" class="text-danger small">
+                            {{ $serialNumberErrors[$i] }}
+                        </td>
+                    </tr>
+                @endif
             @empty
                 <tr>
                     <td colspan="8" class="text-center text-muted">

--- a/resources/views/livewire/transfer/transfer-product-table.blade.php
+++ b/resources/views/livewire/transfer/transfer-product-table.blade.php
@@ -115,6 +115,12 @@
                                         @endif
                                     </div>
 
+                                    @if($loop->first && isset($tableValidationErrors["row.{$i}.serial_numbers"]))
+                                        <div class="text-danger small mt-1">
+                                            {{ $tableValidationErrors["row.{$i}.serial_numbers"] }}
+                                        </div>
+                                    @endif
+
                                     @if(isset($tableValidationErrors["row.{$i}.{$field}"]))
                                         <div class="text-danger small mt-1">
                                             {{ $tableValidationErrors["row.{$i}.{$field}"] }}

--- a/tests/Feature/TransferStockGuardTest.php
+++ b/tests/Feature/TransferStockGuardTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\CheckUserRoleForSetting;
+use App\Http\Middleware\VerifyCsrfToken;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Modules\Adjustment\Entities\Transfer;
+use Modules\Currency\Entities\Currency;
+use Modules\Setting\Entities\Location;
+use Modules\Setting\Entities\Setting;
+use Tests\TestCase;
+
+class TransferStockGuardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Currency $currency;
+
+    private User $user;
+
+    private array $origin;
+
+    private array $destination;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutMiddleware([
+            CheckUserRoleForSetting::class,
+            VerifyCsrfToken::class,
+        ]);
+
+        Gate::shouldReceive('denies')->andReturnFalse()->zeroOrMoreTimes();
+
+        $this->currency = Currency::create([
+            'currency_name'       => 'Rupiah',
+            'code'                => 'IDR',
+            'symbol'              => 'Rp',
+            'thousand_separator'  => '.',
+            'decimal_separator'   => ',',
+            'exchange_rate'       => 1,
+        ]);
+
+        $this->user = User::factory()->create();
+
+        $this->origin = $this->createSettingWithLocation('Origin', 'origin@example.com');
+        $this->destination = $this->createSettingWithLocation('Destination', 'destination@example.com');
+    }
+
+    public function test_dispatch_shipment_blocks_non_origin_tenant(): void
+    {
+        $transfer = Transfer::create([
+            'origin_location_id'      => $this->origin['location']->id,
+            'destination_location_id' => $this->destination['location']->id,
+            'status'                  => Transfer::STATUS_APPROVED,
+            'created_by'              => $this->user->id,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->withSession(['setting_id' => $this->destination['setting']->id])
+            ->post(route('transfers.dispatch', $transfer));
+
+        $response->assertRedirect(route('transfers.show', $transfer->id));
+        $this->assertSame(Transfer::STATUS_APPROVED, $transfer->fresh()->status);
+    }
+
+    public function test_receive_blocks_non_destination_tenant(): void
+    {
+        $transfer = Transfer::create([
+            'origin_location_id'      => $this->origin['location']->id,
+            'destination_location_id' => $this->destination['location']->id,
+            'status'                  => Transfer::STATUS_DISPATCHED,
+            'created_by'              => $this->user->id,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->withSession(['setting_id' => $this->origin['setting']->id])
+            ->post(route('transfers.receive', $transfer));
+
+        $response->assertRedirect(route('transfers.show', $transfer->id));
+        $this->assertSame(Transfer::STATUS_DISPATCHED, $transfer->fresh()->status);
+    }
+
+    public function test_dispatch_return_blocks_non_destination_tenant(): void
+    {
+        $transfer = Transfer::create([
+            'origin_location_id'      => $this->origin['location']->id,
+            'destination_location_id' => $this->destination['location']->id,
+            'status'                  => Transfer::STATUS_RECEIVED,
+            'created_by'              => $this->user->id,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->withSession(['setting_id' => $this->origin['setting']->id])
+            ->post(route('transfers.return-dispatch', $transfer));
+
+        $response->assertRedirect(route('transfers.show', $transfer->id));
+        $this->assertSame(Transfer::STATUS_RECEIVED, $transfer->fresh()->status);
+    }
+
+    public function test_receive_return_blocks_non_origin_tenant(): void
+    {
+        $transfer = Transfer::create([
+            'origin_location_id'      => $this->origin['location']->id,
+            'destination_location_id' => $this->destination['location']->id,
+            'status'                  => Transfer::STATUS_RETURN_DISPATCHED,
+            'created_by'              => $this->user->id,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->withSession(['setting_id' => $this->destination['setting']->id])
+            ->post(route('transfers.return-receive', $transfer));
+
+        $response->assertRedirect(route('transfers.show', $transfer->id));
+        $this->assertSame(Transfer::STATUS_RETURN_DISPATCHED, $transfer->fresh()->status);
+    }
+
+    private function createSettingWithLocation(string $name, string $email): array
+    {
+        $setting = Setting::create([
+            'company_name'             => $name . ' Company',
+            'company_email'            => $email,
+            'company_phone'            => '1234567890',
+            'default_currency_id'      => $this->currency->id,
+            'default_currency_position'=> 'prefix',
+            'notification_email'       => $email,
+            'footer_text'              => 'Footer text',
+            'company_address'          => '123 Street',
+        ]);
+
+        $location = Location::create([
+            'setting_id' => $setting->id,
+            'name'       => $name . ' Location',
+        ]);
+
+        return [
+            'setting'  => $setting,
+            'location' => $location,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- extend transfer schema with return tracking columns and additional status values to support cross-tenant returns
- expand transfer domain logic to enforce staged approvals, dispatch/receive operations, and transactional stock updates for forward and return legs
- refresh transfer UI and livewire form to expose new actions, validations, and routes for the enhanced workflow

## Testing
- `php artisan test` *(fails: vendor directory missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd70bf898832690182a97ff45de7f