### PR TITLE
Ensure session setting IDs use integer comparisons

### DIFF
--- a/Modules/Adjustment/Http/Controllers/TransferStockController.php
+++ b/Modules/Adjustment/Http/Controllers/TransferStockController.php
@@ -42,7 +42,7 @@ class TransferStockController extends Controller
     {
         abort_if(Gate::denies('stockTransfers.create'), 403);
 
-        $currentSettingId = session('setting_id');
+        $currentSettingId = (int) session('setting_id');
         $currentSetting   = Setting::find($currentSettingId);
         $settings         = Setting::all();
         $locations        = Location::where('setting_id', $currentSettingId)->get();
@@ -102,10 +102,13 @@ class TransferStockController extends Controller
             'returnReceivedBy',
         ]);
 
-        $currentSettingId = session('setting_id');
+        $currentSettingId = (int) session('setting_id');
 
-        $isOrigin      = $transfer->originLocation && $currentSettingId === $transfer->originLocation->setting->id;
-        $isDestination = $transfer->destinationLocation && $currentSettingId === $transfer->destinationLocation->setting->id;
+        $originSettingId      = $transfer->originLocation?->setting?->id;
+        $destinationSettingId = $transfer->destinationLocation?->setting?->id;
+
+        $isOrigin      = $originSettingId !== null && $currentSettingId === (int) $originSettingId;
+        $isDestination = $destinationSettingId !== null && $currentSettingId === (int) $destinationSettingId;
         $requiresReturn = $transfer->requiresReturn();
 
         return view('adjustment::transfers.show', compact(

--- a/Modules/Setting/Http/Controllers/BusinessController.php
+++ b/Modules/Setting/Http/Controllers/BusinessController.php
@@ -170,7 +170,7 @@ class BusinessController extends Controller
 
     public function updateActiveBusiness(Request $request): RedirectResponse
     {
-        $settingId = $request->input('setting_id');
+        $settingId = (int) $request->input('setting_id');
 
         // Update the session with the new setting ID
         $request->session()->put('setting_id', $settingId);


### PR DESCRIPTION
## Summary
- cast the active session setting ID to an integer when loading transfer stock views
- compare transfer location setting identifiers using integer values to avoid strict comparison mismatches
- enforce integer casting when updating the active business to keep the stored session ID consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e02cddef3883269ae4ad8c2b8fc14d