### PR TITLE
Restrict stock transfer approval to origin tenant

### DIFF
--- a/Modules/Adjustment/Http/Controllers/TransferStockController.php
+++ b/Modules/Adjustment/Http/Controllers/TransferStockController.php
@@ -126,6 +126,17 @@ class TransferStockController extends Controller
     {
         abort_unless(Gate::any(['stockTransfers.edit', 'stockTransfers.approval']), 403);
 
+        $transfer->loadMissing('originLocation.setting');
+
+        $currentSettingId = (int) session('setting_id');
+        $originSettingId  = $transfer->originLocation?->setting?->id;
+
+        if ($originSettingId === null || $currentSettingId !== (int) $originSettingId) {
+            toast('Transfer hanya dapat disetujui oleh tenant asal.', 'error');
+
+            return redirect()->route('transfers.show', $transfer->id);
+        }
+
         if ($transfer->status !== Transfer::STATUS_PENDING) {
             toast('Transfer tidak dapat disetujui pada status saat ini.', 'error');
 
@@ -149,6 +160,17 @@ class TransferStockController extends Controller
     public function reject(Transfer $transfer): RedirectResponse
     {
         abort_unless(Gate::any(['stockTransfers.edit', 'stockTransfers.approval']), 403);
+
+        $transfer->loadMissing('originLocation.setting');
+
+        $currentSettingId = (int) session('setting_id');
+        $originSettingId  = $transfer->originLocation?->setting?->id;
+
+        if ($originSettingId === null || $currentSettingId !== (int) $originSettingId) {
+            toast('Transfer hanya dapat ditolak oleh tenant asal.', 'error');
+
+            return redirect()->route('transfers.show', $transfer->id);
+        }
 
         if ($transfer->status !== Transfer::STATUS_PENDING) {
             toast('Transfer tidak dapat ditolak pada status saat ini.', 'error');

--- a/Modules/Adjustment/Resources/views/transfers/show.blade.php
+++ b/Modules/Adjustment/Resources/views/transfers/show.blade.php
@@ -140,8 +140,8 @@
                         </table>
 
                         <div class="mt-4">
-                            {{-- Approve/Reject: only DESTINATION on PENDING --}}
-                            @if($transfer->status === Transfer::STATUS_PENDING && $isDestination)
+                            {{-- Approve/Reject: only ORIGIN on PENDING --}}
+                            @if($transfer->status === Transfer::STATUS_PENDING && $isOrigin)
                                 @canany(['stockTransfers.edit','stockTransfers.approval'])
                                     <form action="{{ route('transfers.approve', $transfer) }}" method="POST"
                                           class="d-inline">


### PR DESCRIPTION
## Summary
- show approve/reject actions for pending transfers only when viewed from the origin tenant
- block approve and reject endpoints when the active setting does not match the origin tenant

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e030e7a6cc83268e8dee4ba70cc009