### PR TITLE
Add serial number selection to transfer stock table

### DIFF
--- a/app/Livewire/Transfer/TransferProductTable.php
+++ b/app/Livewire/Transfer/TransferProductTable.php
@@ -3,14 +3,16 @@
 namespace App\Livewire\Transfer;
 
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Log;
 use Livewire\Component;
+use Modules\Product\Entities\ProductSerialNumber;
 use Modules\Product\Entities\ProductStock;
 
 class TransferProductTable extends Component
 {
     protected $listeners = [
         'productSelected',
+        'serialNumberSelected',
+        'removeSerialNumber',
         'locationsConfirmed'      => 'resetOnNewLocations',
         'tableValidationErrors'   => 'onTableValidationErrors',
     ];
@@ -18,6 +20,7 @@ class TransferProductTable extends Component
     public $products = [];
     public $originLocationId;
     public $destinationLocationId;
+    public $serialNumberErrors = [];
 
     // holds validation errors for table rows
     public $tableValidationErrors = [];
@@ -30,6 +33,7 @@ class TransferProductTable extends Component
         $this->originLocationId      = $originLocationId;
         $this->destinationLocationId = $destinationLocationId;
         $this->products              = [];
+        $this->serialNumberErrors    = [];
     }
 
     /**
@@ -40,6 +44,7 @@ class TransferProductTable extends Component
         $this->originLocationId      = $payload['originLocationId'];
         $this->destinationLocationId = $payload['destinationLocationId'];
         $this->products              = [];
+        $this->serialNumberErrors    = [];
         $this->tableValidationErrors = [];
 
         // notify parent of reset
@@ -76,8 +81,11 @@ class TransferProductTable extends Component
         $product['quantity_non_tax']        = 0;
         $product['broken_quantity_tax']     = 0;
         $product['broken_quantity_non_tax'] = 0;
+        $product['serial_number_required']  = (bool) ($product['serial_number_required'] ?? false);
+        $product['serial_numbers']          = [];
 
         $this->products[] = $product;
+        $this->serialNumberErrors[] = null;
         $this->tableValidationErrors = [];
 
         // notify parent that rows have changed
@@ -91,10 +99,143 @@ class TransferProductTable extends Component
     {
         unset($this->products[$key]);
         $this->products = array_values($this->products);
+        unset($this->serialNumberErrors[$key]);
+        $this->serialNumberErrors = array_values($this->serialNumberErrors);
         $this->tableValidationErrors = [];
 
         // notify parent that rows have changed
         $this->dispatch('rowsUpdated', $this->products);
+    }
+
+    public function serialNumberSelected($payload): void
+    {
+        $productCompositeKey = $payload['productCompositeKey'] ?? null;
+
+        if (! is_numeric($productCompositeKey)) {
+            return;
+        }
+
+        $rowKey = (int) $productCompositeKey;
+
+        if (! isset($this->products[$rowKey])) {
+            return;
+        }
+
+        if (empty($this->products[$rowKey]['serial_number_required'])) {
+            return;
+        }
+
+        $serialNumber = $payload['serialNumber'] ?? null;
+        $serialId     = (int) ($serialNumber['id'] ?? 0);
+
+        if ($serialId <= 0) {
+            return;
+        }
+
+        // Prevent duplicate selections across all rows
+        if ($this->serialExistsInRows($serialId, $rowKey)) {
+            $this->serialNumberErrors[$rowKey] = 'Nomor seri sudah dipilih.';
+            return;
+        }
+
+        $serial = ProductSerialNumber::find($serialId);
+
+        if (! $serial) {
+            $this->serialNumberErrors[$rowKey] = 'Nomor seri tidak ditemukan.';
+            return;
+        }
+
+        $currentSerials = collect($this->products[$rowKey]['serial_numbers'] ?? []);
+
+        if ($currentSerials->pluck('id')->contains($serial->id)) {
+            $this->serialNumberErrors[$rowKey] = 'Nomor seri sudah dipilih.';
+            return;
+        }
+
+        $this->serialNumberErrors[$rowKey] = null;
+
+        $this->products[$rowKey]['serial_numbers'][] = [
+            'id'            => $serial->id,
+            'serial_number' => $serial->serial_number,
+            'tax_id'        => $serial->tax_id,
+            'taxable'       => (bool) $serial->tax_id,
+            'is_broken'     => (bool) $serial->is_broken,
+        ];
+
+        $this->recalculateSerialQuantities($rowKey);
+
+        $this->dispatch('rowsUpdated', $this->products);
+    }
+
+    public function removeSerialNumber($rowKey, $serialIndex = null): void
+    {
+        if (is_array($rowKey)) {
+            $serialIndex = $rowKey['serialIndex'] ?? null;
+            $rowKey      = $rowKey['productCompositeKey'] ?? $rowKey['row'] ?? null;
+        }
+
+        if (! is_numeric($rowKey)) {
+            return;
+        }
+
+        $rowKey = (int) $rowKey;
+
+        if (! isset($this->products[$rowKey]) || $serialIndex === null) {
+            return;
+        }
+
+        if (! isset($this->products[$rowKey]['serial_numbers'][$serialIndex])) {
+            return;
+        }
+
+        unset($this->products[$rowKey]['serial_numbers'][$serialIndex]);
+        $this->products[$rowKey]['serial_numbers'] = array_values($this->products[$rowKey]['serial_numbers']);
+
+        $this->serialNumberErrors[$rowKey] = null;
+
+        $this->recalculateSerialQuantities($rowKey);
+
+        $this->dispatch('rowsUpdated', $this->products);
+    }
+
+    protected function serialExistsInRows(int $serialId, int $currentRowKey): bool
+    {
+        return collect($this->products)
+            ->filter(fn ($_, $index) => $index !== $currentRowKey)
+            ->pluck('serial_numbers')
+            ->flatten(1)
+            ->pluck('id')
+            ->contains($serialId);
+    }
+
+    protected function recalculateSerialQuantities(int $rowKey): void
+    {
+        $serials = $this->products[$rowKey]['serial_numbers'] ?? [];
+
+        $quantityTax            = 0;
+        $quantityNonTax        = 0;
+        $brokenQuantityTax     = 0;
+        $brokenQuantityNonTax  = 0;
+
+        foreach ($serials as $serial) {
+            $isBroken = (bool) ($serial['is_broken'] ?? false);
+            $isTaxed  = (bool) ($serial['taxable'] ?? false);
+
+            if ($isBroken && $isTaxed) {
+                $brokenQuantityTax++;
+            } elseif ($isBroken && ! $isTaxed) {
+                $brokenQuantityNonTax++;
+            } elseif (! $isBroken && $isTaxed) {
+                $quantityTax++;
+            } else {
+                $quantityNonTax++;
+            }
+        }
+
+        $this->products[$rowKey]['quantity_tax']            = $quantityTax;
+        $this->products[$rowKey]['quantity_non_tax']        = $quantityNonTax;
+        $this->products[$rowKey]['broken_quantity_tax']     = $brokenQuantityTax;
+        $this->products[$rowKey]['broken_quantity_non_tax'] = $brokenQuantityNonTax;
     }
 
     /**

--- a/resources/views/livewire/transfer/transfer-product-table.blade.php
+++ b/resources/views/livewire/transfer/transfer-product-table.blade.php
@@ -50,27 +50,91 @@
 
                     @php
                         $fields = [
-                            'quantity_tax'             => 'Jumlah Pajak',
-                            'quantity_non_tax'         => 'Jumlah Non Pajak',
-                            'broken_quantity_tax'      => 'Rusak Pajak',
-                            'broken_quantity_non_tax'  => 'Rusak Non Pajak',
+                            'quantity_tax'             => ['label' => 'Jumlah Pajak', 'is_taxed' => true,  'is_broken' => false],
+                            'quantity_non_tax'         => ['label' => 'Jumlah Non Pajak', 'is_taxed' => false, 'is_broken' => false],
+                            'broken_quantity_tax'      => ['label' => 'Rusak Pajak', 'is_taxed' => true,  'is_broken' => true],
+                            'broken_quantity_non_tax'  => ['label' => 'Rusak Non Pajak', 'is_taxed' => false, 'is_broken' => true],
                         ];
+                        $serialRequired = $p['serial_number_required'] ?? false;
+                        $serials = collect($p['serial_numbers'] ?? []);
                     @endphp
 
-                    @foreach($fields as $field => $label)
+                    @foreach($fields as $field => $config)
                         <td>
-                            <input
-                                type="number"
-                                min="0"
-                                class="form-control"
-                                wire:model.lazy="products.{{ $i }}.{{ $field }}"
-                            >
+                            @if($serialRequired)
+                                <div class="d-flex flex-column">
+                                    <div class="mb-2">
+                                        @if($originLocationId)
+                                            <livewire:auto-complete.serial-number-loader
+                                                :location-id="$originLocationId"
+                                                :product-id="$p['id']"
+                                                :is-taxed="$config['is_taxed']"
+                                                :is-broken="$config['is_broken']"
+                                                :serial-index="'transfer-' . $field . '-' . $i"
+                                                :product-composite-key="$i"
+                                                :is-dispatch="true"
+                                                wire:key="transfer-serial-{{ $field }}-{{ $i }}"
+                                            />
+                                        @else
+                                            <div class="alert alert-warning mb-2 py-1 px-2">
+                                                <small>Pilih lokasi asal terlebih dahulu.</small>
+                                            </div>
+                                        @endif
+                                    </div>
 
-                            {{-- field-level error --}}
-                            @if(isset($tableValidationErrors["row.{$i}.{$field}"]))
-                                <div class="text-danger small mt-1">
-                                    {{ $tableValidationErrors["row.{$i}.{$field}"] }}
+                                    <div class="form-control-plaintext text-center font-weight-bold">
+                                        {{ $p[$field] ?? 0 }}
+                                    </div>
+
+                                    @php
+                                        $filteredSerials = $serials->filter(function ($serial, $serialIndex) use ($config) {
+                                            $matchesTax   = (bool) ($serial['taxable'] ?? false) === (bool) $config['is_taxed'];
+                                            $matchesBroken = (bool) ($serial['is_broken'] ?? false) === (bool) $config['is_broken'];
+
+                                            return $matchesTax && $matchesBroken;
+                                        });
+                                    @endphp
+
+                                    <div class="mt-2">
+                                        @if($filteredSerials->isEmpty())
+                                            <small class="text-muted">Belum ada nomor seri.</small>
+                                        @else
+                                            <div class="d-flex flex-wrap">
+                                                @foreach($filteredSerials as $serialIndex => $serial)
+                                                    <span class="badge badge-light border d-flex align-items-center mb-1 mr-1">
+                                                        <span>{{ $serial['serial_number'] }}</span>
+                                                        <button type="button"
+                                                            class="btn btn-link btn-sm text-danger p-0 ml-2"
+                                                            wire:click="removeSerialNumber({{ $i }}, {{ $serialIndex }})"
+                                                            title="Hapus nomor seri">
+                                                            <i class="bi bi-x-circle"></i>
+                                                        </button>
+                                                    </span>
+                                                @endforeach
+                                            </div>
+                                        @endif
+                                    </div>
+
+                                    @if(isset($tableValidationErrors["row.{$i}.{$field}"]))
+                                        <div class="text-danger small mt-1">
+                                            {{ $tableValidationErrors["row.{$i}.{$field}"] }}
+                                        </div>
+                                    @endif
                                 </div>
+                            @else
+                                <input
+                                    type="number"
+                                    min="0"
+                                    class="form-control"
+                                    wire:model.lazy="products.{{ $i }}.{{ $field }}"
+                                >
+
+                                {{-- field-level error --}}
+                                @if(isset($tableValidationErrors["row.{$i}.{$field}"]))
+                                    <div class="text-danger small mt-1">
+                                        {{ $tableValidationErrors["row.{$i}.{$field}"] }}
+                                    </div>
+                                @endif
                             @endif
                         </td>
                     @endforeach
@@ -85,6 +149,13 @@
                         </button>
                     </td>
                 </tr>
+                @if(($p['serial_number_required'] ?? false) && !empty($serialNumberErrors[$i]))
+                    <tr>
+                        <td colspan="8" class="text-danger small">
+                            {{ $serialNumberErrors[$i] }}
+                        </td>
+                    </tr>
+                @endif
             @empty
                 <tr>
                     <td colspan="8" class="text-center text-muted">


### PR DESCRIPTION
## Summary
- track per-row serial number selections in the transfer product table and keep stock breakdowns in sync
- render serial number autocomplete pickers with dispatch filtering and show read-only quantity counts for serial-managed items

## Testing
- php -l app/Livewire/Transfer/TransferProductTable.php

------
https://chatgpt.com/codex/tasks/task_e_68e036c89df48326aef994011deb9f9e