### PR TITLE
Handle missing stock when selecting transfer products

### DIFF
--- a/app/Livewire/Transfer/TransferProductTable.php
+++ b/app/Livewire/Transfer/TransferProductTable.php
@@ -69,11 +69,11 @@ class TransferProductTable extends Component
 
         // merge in all the relevant stock columns
         $product['stock'] = [
-            'total'                   => $stock->quantity                 ?? 0,
-            'quantity_tax'            => $stock->quantity_tax             ?? 0,
-            'quantity_non_tax'        => $stock->quantity_non_tax         ?? 0,
-            'broken_quantity_tax'     => $stock->broken_quantity_tax      ?? 0,
-            'broken_quantity_non_tax' => $stock->broken_quantity_non_tax  ?? 0,
+            'total'                   => $stock?->quantity                 ?? 0,
+            'quantity_tax'            => $stock?->quantity_tax             ?? 0,
+            'quantity_non_tax'        => $stock?->quantity_non_tax         ?? 0,
+            'broken_quantity_tax'     => $stock?->broken_quantity_tax      ?? 0,
+            'broken_quantity_non_tax' => $stock?->broken_quantity_non_tax  ?? 0,
         ];
 
         // initialize transfer inputs


### PR DESCRIPTION
## Summary
- allow transfer product table to initialise when a product has no stock snapshot by null-safe stock lookups

## Testing
- not run (UI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e03d6a5e0c8326babf4aaabf8a47d7