### PR TITLE
Display serial number validation errors in transfer product table

### DIFF
--- a/resources/views/livewire/transfer/transfer-product-table.blade.php
+++ b/resources/views/livewire/transfer/transfer-product-table.blade.php
@@ -115,6 +115,12 @@
                                         @endif
                                     </div>
 
+                                    @if($loop->first && isset($tableValidationErrors["row.{$i}.serial_numbers"]))
+                                        <div class="text-danger small mt-1">
+                                            {{ $tableValidationErrors["row.{$i}.serial_numbers"] }}
+                                        </div>
+                                    @endif
+
                                     @if(isset($tableValidationErrors["row.{$i}.{$field}"]))
                                         <div class="text-danger small mt-1">
                                             {{ $tableValidationErrors["row.{$i}.{$field}"] }}


### PR DESCRIPTION
## Summary
- render validation feedback for `row.{i}.serial_numbers` beneath the serial picker so required-serial messages are visible in the transfer product table

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e03e3edc8c8326ad16ff3b91ff7d47