### PR TITLE
Allow destination tenants to see pending transfers

### DIFF
--- a/Modules/Adjustment/DataTables/StockTransfersDataTable.php
+++ b/Modules/Adjustment/DataTables/StockTransfersDataTable.php
@@ -48,12 +48,11 @@ class StockTransfersDataTable extends DataTable
                 $q->whereHas('originLocation.setting', function ($q1) use ($settingId) {
                     $q1->where('id', $settingId);
                 })
-                    // 2) OR: transfers where current setting is the DESTINATION AND status is DISPATCHED
+                    // 2) OR: transfers where current setting is the DESTINATION regardless of status
                     ->orWhere(function($q2) use ($settingId) {
                         $q2->whereHas('destinationLocation.setting', function ($q3) use ($settingId) {
                             $q3->where('id', $settingId);
-                        })
-                            ->where('status', 'DISPATCHED');
+                        });
                     });
             });
     }


### PR DESCRIPTION
## Summary
- allow destination tenants to see transfers targeting them regardless of status
- retain existing origin filter logic to avoid regressions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e04ad1f2708326a2e0be66920ff0be