### PR TITLE
Add tenant context to stock transfers datatable

### DIFF
--- a/Modules/Adjustment/DataTables/StockTransfersDataTable.php
+++ b/Modules/Adjustment/DataTables/StockTransfersDataTable.php
@@ -32,10 +32,42 @@ class StockTransfersDataTable extends DataTable
                 return $data->created_at ? $data->created_at->format('Y-m-d H:i:s') : '-';
             })
             ->addColumn('origin_location_name', function ($data) {
-                return $data->originLocation ? $data->originLocation->name : '-';
+                $location = $data->originLocation;
+
+                if (! $location) {
+                    return '-';
+                }
+
+                $name            = $location->name ?? '-';
+                $currentSetting  = session('setting_id');
+                $locationSetting = $location->setting_id;
+
+                if ($locationSetting && (string) $locationSetting !== (string) $currentSetting) {
+                    $tenant = optional($location->setting)->company_name ?? ('Setting #' . $locationSetting);
+
+                    return sprintf('%s (%s)', $name, $tenant);
+                }
+
+                return $name;
             })
             ->addColumn('destination_location_name', function ($data) {
-                return $data->destinationLocation ? $data->destinationLocation->name : '-';
+                $location = $data->destinationLocation;
+
+                if (! $location) {
+                    return '-';
+                }
+
+                $name            = $location->name ?? '-';
+                $currentSetting  = session('setting_id');
+                $locationSetting = $location->setting_id;
+
+                if ($locationSetting && (string) $locationSetting !== (string) $currentSetting) {
+                    $tenant = optional($location->setting)->company_name ?? ('Setting #' . $locationSetting);
+
+                    return sprintf('%s (%s)', $name, $tenant);
+                }
+
+                return $name;
             });
     }
 
@@ -45,7 +77,7 @@ class StockTransfersDataTable extends DataTable
         $settingId = session('setting_id');
 
         return $model->newQuery()
-            ->with('originLocation', 'destinationLocation')
+            ->with(['originLocation.setting', 'destinationLocation.setting'])
             ->where(function($q) use ($settingId) {
                 // 1) All transfers where current setting is the ORIGIN
                 $q->whereHas('originLocation.setting', function ($q1) use ($settingId) {


### PR DESCRIPTION
## Summary
- eager-load origin and destination location settings for the stock transfers datatable
- append tenant names to origin and destination labels when the transfer crosses businesses
- keep the document number column visible for quick cross-tenant identification

## Testing
- php -l Modules/Adjustment/DataTables/StockTransfersDataTable.php

------
https://chatgpt.com/codex/tasks/task_e_68e056a3e42483268da3ac99bed59ee0