### PR TITLE
Add location scoping to serial number loader

### DIFF
--- a/app/Livewire/AutoComplete/SerialNumberLoader.php
+++ b/app/Livewire/AutoComplete/SerialNumberLoader.php
@@ -64,6 +64,10 @@ class SerialNumberLoader extends Component
             ]);
 
             $baseQuery = ProductSerialNumber::where('serial_number', 'like', '%' . $this->query . '%')
+                ->when(
+                    $this->location_id,
+                    fn($query) => $query->where('location_id', $this->location_id)
+                )
                 ->when($this->product_id > 0, fn($query) => $query->where('product_id', $this->product_id))
                 ->when($this->is_taxed,
                     fn($query) => $query->whereNotNull('tax_id')->where('tax_id', '>', 0),
@@ -84,7 +88,14 @@ class SerialNumberLoader extends Component
 
     public function selectSerialNumber($serialNumberId): void
     {
-        $serialNumber = ProductSerialNumber::find($serialNumberId);
+        $serialNumber = ProductSerialNumber::query()
+            ->whereKey($serialNumberId)
+            ->when(
+                $this->location_id,
+                fn($query) => $query->where('location_id', $this->location_id)
+            )
+            ->first();
+
         if ($serialNumber) {
             $this->search_results = [$serialNumber];
             $this->query = "$serialNumber->serial_number";


### PR DESCRIPTION
## Summary
- scope serial number searches by the selected location when provided
- guard serial selection so only records from the current location are emitted

## Testing
- php artisan test *(fails: composer install cannot run on PHP 8.4 due to dependency constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68e05ebd94248326b02ef95e33969133