### PR TITLE
Ensure serial loader respects broken flag

### DIFF
--- a/app/Livewire/AutoComplete/SerialNumberLoader.php
+++ b/app/Livewire/AutoComplete/SerialNumberLoader.php
@@ -75,7 +75,10 @@ class SerialNumberLoader extends Component
                         $q->whereNull('tax_id')->orWhere('tax_id', 0);
                     })
                 )
-                ->when($this->is_broken, fn($query) => $query->where('is_broken', true))
+                ->when(
+                    ! is_null($this->is_broken),
+                    fn($query) => $query->where('is_broken', (bool) $this->is_broken)
+                )
                 ->when($this->is_dispatch, fn($query) => $query->whereNull('dispatch_detail_id'));
 
             $this->query_count = $baseQuery->count();


### PR DESCRIPTION
## Summary
- ensure the serial number autocomplete query always filters by the requested broken flag state

## Testing
- not run (vendor directory missing in container)


------
https://chatgpt.com/codex/tasks/task_e_68e05f88083c8326ac464bccda32fde8