### PR TITLE
Ensure purchase return approvals default to pending

### DIFF
--- a/Modules/PurchasesReturn/Database/Migrations/2025_09_23_100001_backfill_pending_purchase_returns.php
+++ b/Modules/PurchasesReturn/Database/Migrations/2025_09_23_100001_backfill_pending_purchase_returns.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::table('purchase_returns')
+            ->where('approval_status', 'draft')
+            ->whereNull('approved_at')
+            ->whereNull('rejected_at')
+            ->update(['approval_status' => 'pending']);
+    }
+
+    public function down(): void
+    {
+        DB::table('purchase_returns')
+            ->where('approval_status', 'pending')
+            ->whereNull('approved_at')
+            ->whereNull('rejected_at')
+            ->update(['approval_status' => 'draft']);
+    }
+};

--- a/Modules/PurchasesReturn/Http/Controllers/PurchasesReturnController.php
+++ b/Modules/PurchasesReturn/Http/Controllers/PurchasesReturnController.php
@@ -62,6 +62,7 @@ class PurchasesReturnController extends Controller
                 'paid_amount' => $request->paid_amount * 100,
                 'total_amount' => $request->total_amount * 100,
                 'due_amount' => $due_amount * 100,
+                'approval_status' => 'pending',
                 'status' => $request->status,
                 'payment_status' => $payment_status,
                 'payment_method' => $request->payment_method,
@@ -180,6 +181,10 @@ class PurchasesReturnController extends Controller
                 $payment_status = 'Paid';
             }
 
+            $approvalStatus = $purchase_return->approval_status === 'approved'
+                ? 'approved'
+                : 'pending';
+
             foreach ($purchase_return->purchaseReturnDetails as $purchase_return_detail) {
                 if ($purchase_return->status == 'Shipped' || $purchase_return->status == 'Completed') {
                     $product = Product::findOrFail($purchase_return_detail->product_id);
@@ -201,6 +206,7 @@ class PurchasesReturnController extends Controller
                 'paid_amount' => $request->paid_amount * 100,
                 'total_amount' => $request->total_amount * 100,
                 'due_amount' => $due_amount * 100,
+                'approval_status' => $approvalStatus,
                 'status' => $request->status,
                 'payment_status' => $payment_status,
                 'payment_method' => $request->payment_method,


### PR DESCRIPTION
## Summary
- default new purchase returns created through the controller to a pending approval status
- keep existing approved purchase returns approved during edits while forcing other updates back to pending
- add a data migration that backfills draft purchase returns without approval or rejection timestamps to pending

## Testing
- ⚠️ `php artisan test` *(fails: vendor/autoload.php missing because Composer dependencies cannot be installed under PHP 8.4)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d91f78808326a3cc3c2e51bafdcb