### PR TITLE
Normalize purchase return approval status handling

### DIFF
--- a/Modules/PurchasesReturn/Entities/PurchaseReturn.php
+++ b/Modules/PurchasesReturn/Entities/PurchaseReturn.php
@@ -107,18 +107,18 @@ class PurchaseReturn extends BaseModel
 
     public function scopeApproved($q)
     {
-        return $q->where('approval_status', 'approved');
+        return $q->whereRaw('LOWER(approval_status) = ?', ['approved']);
     }
     public function scopePending($q)
     {
-        return $q->where('approval_status', 'pending');
+        return $q->whereRaw('LOWER(approval_status) = ?', ['pending']);
     }
     public function scopeRejected($q)
     {
-        return $q->where('approval_status', 'rejected');
+        return $q->whereRaw('LOWER(approval_status) = ?', ['rejected']);
     }
     public function scopeDraft($q)
     {
-        return $q->where('approval_status', 'draft');
+        return $q->whereRaw('LOWER(approval_status) = ?', ['draft']);
     }
 }

--- a/Modules/PurchasesReturn/Http/Controllers/PurchasesReturnController.php
+++ b/Modules/PurchasesReturn/Http/Controllers/PurchasesReturnController.php
@@ -4,6 +4,7 @@ namespace Modules\PurchasesReturn\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 use Modules\PurchasesReturn\DataTables\PurchaseReturnsDataTable;
 use Gloudemans\Shoppingcart\Facades\Cart;
 use Illuminate\Routing\Controller;
@@ -127,7 +128,9 @@ class PurchasesReturnController extends Controller
     {
         abort_if(Gate::denies('purchaseReturns.edit'), 403);
 
-        if ($purchase_return->approval_status !== 'approved') {
+        $status = Str::lower($purchase_return->approval_status ?? '');
+
+        if ($status !== 'approved') {
             toast('Penyelesaian hanya dapat diproses setelah retur disetujui.', 'error');
             return redirect()->route('purchase-returns.show', $purchase_return);
         }
@@ -181,7 +184,9 @@ class PurchasesReturnController extends Controller
                 $payment_status = 'Paid';
             }
 
-            $approvalStatus = $purchase_return->approval_status === 'approved'
+            $status = Str::lower($purchase_return->approval_status ?? '');
+
+            $approvalStatus = $status === 'approved'
                 ? 'approved'
                 : 'pending';
 
@@ -261,7 +266,9 @@ class PurchasesReturnController extends Controller
     {
         abort_if(Gate::denies('purchaseReturns.edit'), 403);
 
-        if ($purchase_return->approval_status === 'approved') {
+        $status = Str::lower($purchase_return->approval_status ?? '');
+
+        if ($status === 'approved') {
             toast('Retur pembelian sudah disetujui.', 'info');
             return back();
         }
@@ -287,7 +294,9 @@ class PurchasesReturnController extends Controller
     {
         abort_if(Gate::denies('purchaseReturns.edit'), 403);
 
-        if ($purchase_return->approval_status === 'approved') {
+        $status = Str::lower($purchase_return->approval_status ?? '');
+
+        if ($status === 'approved') {
             toast('Retur yang sudah disetujui tidak dapat ditolak.', 'error');
             return back();
         }

--- a/Modules/PurchasesReturn/Resources/views/partials/actions.blade.php
+++ b/Modules/PurchasesReturn/Resources/views/partials/actions.blade.php
@@ -1,10 +1,11 @@
+@php $approvalStatus = strtolower($data->approval_status ?? ''); @endphp
 <div class="btn-group dropleft">
     <button type="button" class="btn btn-ghost-primary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
         <i class="bi bi-three-dots-vertical"></i>
     </button>
     <div class="dropdown-menu dropdown-menu-right shadow-sm">
         @can('purchaseReturns.edit')
-            @if($data->approval_status === 'pending')
+            @if($approvalStatus === 'pending')
                 <a href="{{ route('purchase-returns.edit', $data->id) }}" class="dropdown-item d-flex align-items-center">
                     <i class="bi bi-pencil text-primary me-2"></i> <span>Edit</span>
                 </a>
@@ -12,7 +13,7 @@
         @endcan
 
         @can('purchaseReturns.edit')
-            @if($data->approval_status === 'pending')
+            @if($approvalStatus === 'pending')
                 <form method="POST" action="{{ route('purchase-returns.approve', $data->id) }}" class="m-0">
                     @csrf
                     <button type="submit" class="dropdown-item d-flex align-items-center border-0 bg-transparent px-0" onclick="return confirm('Setujui retur pembelian ini?')">
@@ -45,7 +46,7 @@
             </a>
         @endcan
 
-        @if($data->approval_status === 'approved')
+        @if($approvalStatus === 'approved')
             @can('purchaseReturns.edit')
                 <a href="{{ route('purchase-returns.settlement', $data->id) }}" class="dropdown-item d-flex align-items-center">
                     <i class="bi bi-arrow-repeat text-primary me-2"></i> <span>Kelola Penyelesaian</span>
@@ -60,7 +61,7 @@
         @endif
 
         @can('purchaseReturns.delete')
-            @if($data->approval_status === 'pending')
+            @if($approvalStatus === 'pending')
                 <button id="delete" type="button" class="dropdown-item d-flex align-items-center" onclick="
                     event.preventDefault();
                     if (confirm('Anda Yakin untuk Menghapus? Data akan Terhapus Permanen!')) {

--- a/Modules/PurchasesReturn/Resources/views/partials/settlement-status.blade.php
+++ b/Modules/PurchasesReturn/Resources/views/partials/settlement-status.blade.php
@@ -2,6 +2,7 @@
     $badgeClass = 'badge bg-secondary';
     $label = 'Belum Diproses';
     $description = null;
+    $approvalStatus = strtolower($data->approval_status ?? '');
 
     $methodMap = [
         'Cash' => 'Pengembalian Tunai',
@@ -15,19 +16,19 @@
         if ($data->payment_method) {
             $description = 'Metode: ' . ($methodMap[$data->payment_method] ?? $data->payment_method);
         }
-    } elseif ($data->approval_status === 'rejected') {
+    } elseif ($approvalStatus === 'rejected') {
         $badgeClass = 'badge bg-danger';
         $label = 'Ditolak';
         if ($data->rejection_reason) {
             $description = 'Alasan: ' . $data->rejection_reason;
         }
-    } elseif ($data->status === 'Awaiting Settlement' || ($data->approval_status === 'approved' && ! $data->settled_at)) {
+    } elseif ($data->status === 'Awaiting Settlement' || ($approvalStatus === 'approved' && ! $data->settled_at)) {
         $badgeClass = 'badge bg-info text-dark';
         $label = 'Menunggu Penyelesaian';
         if (empty($data->return_type)) {
             $description = 'Metode penyelesaian belum dipilih.';
         }
-    } elseif ($data->approval_status !== 'approved') {
+    } elseif ($approvalStatus !== 'approved') {
         $badgeClass = 'badge bg-warning text-dark';
         $label = 'Menunggu Persetujuan';
     }

--- a/Modules/PurchasesReturn/Resources/views/print.blade.php
+++ b/Modules/PurchasesReturn/Resources/views/print.blade.php
@@ -18,23 +18,24 @@
 
     $settlementLabel = 'Belum Diproses';
     $settlementDetail = null;
+    $approvalStatus = strtolower($purchase_return->approval_status ?? '');
 
     if ($purchase_return->settled_at) {
         $settlementLabel = 'Selesai';
         if ($purchase_return->payment_method) {
             $settlementDetail = 'Metode: ' . ($methodMap[$purchase_return->payment_method] ?? $purchase_return->payment_method);
         }
-    } elseif ($purchase_return->approval_status === 'rejected') {
+    } elseif ($approvalStatus === 'rejected') {
         $settlementLabel = 'Ditolak';
         if ($purchase_return->rejection_reason) {
             $settlementDetail = 'Alasan: ' . $purchase_return->rejection_reason;
         }
-    } elseif ($purchase_return->status === 'Awaiting Settlement' || ($purchase_return->approval_status === 'approved' && ! $purchase_return->settled_at)) {
+    } elseif ($purchase_return->status === 'Awaiting Settlement' || ($approvalStatus === 'approved' && ! $purchase_return->settled_at)) {
         $settlementLabel = 'Menunggu Penyelesaian';
         if (empty($purchase_return->return_type)) {
             $settlementDetail = 'Metode penyelesaian belum dipilih.';
         }
-    } elseif ($purchase_return->approval_status !== 'approved') {
+    } elseif ($approvalStatus !== 'approved') {
         $settlementLabel = 'Menunggu Persetujuan';
     }
 @endphp

--- a/Modules/PurchasesReturn/Resources/views/show.blade.php
+++ b/Modules/PurchasesReturn/Resources/views/show.blade.php
@@ -1,4 +1,5 @@
 @php use Illuminate\Support\Facades\Storage; @endphp
+@php $approvalStatus = strtolower($purchase_return->approval_status ?? ''); @endphp
 @extends('layouts.app')
 
 @section('title', 'Detail Retur Pembelian')
@@ -12,7 +13,7 @@
 @endsection
 
 @can('purchaseReturns.edit')
-    @if($purchase_return->approval_status === 'pending')
+    @if($approvalStatus === 'pending')
         @push('page_scripts')
             <script>
                 function purchaseReturnReject{{ $purchase_return->id }}() {
@@ -40,9 +41,9 @@
                         </div>
                         <div class="ms-auto d-flex flex-wrap align-items-center">
                             <span class="badge bg-secondary text-uppercase me-2 mb-1">{{ $purchase_return->status }}</span>
-                            <span class="badge {{ $purchase_return->approval_status === 'approved' ? 'bg-success' : ($purchase_return->approval_status === 'rejected' ? 'bg-danger' : 'bg-warning text-dark') }} text-uppercase me-2 mb-1">{{ $purchase_return->approval_status }}</span>
+                            <span class="badge {{ $approvalStatus === 'approved' ? 'bg-success' : ($approvalStatus === 'rejected' ? 'bg-danger' : 'bg-warning text-dark') }} text-uppercase me-2 mb-1">{{ $purchase_return->approval_status }}</span>
                             @can('purchaseReturns.edit')
-                                @if($purchase_return->approval_status === 'pending')
+                                @if($approvalStatus === 'pending')
                                     <a class="btn btn-primary btn-sm d-print-none me-2 mb-1" href="{{ route('purchase-returns.edit', $purchase_return) }}">
                                         <i class="bi bi-pencil"></i> Edit
                                     </a>
@@ -59,7 +60,7 @@
                                     <button type="button" class="btn btn-outline-danger btn-sm d-print-none me-2 mb-1" onclick="purchaseReturnReject{{ $purchase_return->id }}()">
                                         <i class="bi bi-x-circle"></i> Tolak
                                     </button>
-                                @elseif($purchase_return->approval_status === 'approved')
+                                @elseif($approvalStatus === 'approved')
                                     <a class="btn btn-primary btn-sm d-print-none me-2 mb-1" href="{{ route('purchase-returns.settlement', $purchase_return->id) }}">
                                         <i class="bi bi-arrow-repeat"></i> Kelola Penyelesaian
                                     </a>
@@ -171,7 +172,7 @@
                             </div>
                         </div>
 
-                        @if(!$purchase_return->return_type && $purchase_return->approval_status === 'approved')
+                        @if(!$purchase_return->return_type && $approvalStatus === 'approved')
                             <div class="alert alert-warning mt-4" role="alert">
                                 Metode penyelesaian belum ditentukan. Silakan proses melalui halaman penyelesaian retur.
                             </div>


### PR DESCRIPTION
## Summary
- normalize approval status checks in the purchase return controller to tolerate mixed-case data
- update purchase return views to derive UI state from a lowercase approval status value
- adjust purchase return scopes to query approval states with case-insensitive comparisons

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0e3a0e27c83269c5781776130a052