### PR TITLE
Fix PurchaseReturn edit form mount handling

### DIFF
--- a/app/Livewire/PurchaseReturn/PurchaseReturnEditForm.php
+++ b/app/Livewire/PurchaseReturn/PurchaseReturnEditForm.php
@@ -18,8 +18,14 @@ class PurchaseReturnEditForm extends PurchaseReturnCreateForm
 {
     public PurchaseReturn $purchaseReturn;
 
-    public function mount(PurchaseReturn $purchaseReturn): void
+    public function mount(?PurchaseReturn $purchaseReturn = null): void
     {
+        parent::mount();
+
+        if (! $purchaseReturn) {
+            abort(404);
+        }
+
         $this->purchaseReturn = $purchaseReturn->loadMissing([
             'purchaseReturnDetails.product',
             'purchaseReturnDetails.purchase',


### PR DESCRIPTION
## Summary
- align the edit form mount signature with the base component while still accepting the bound model
- run the base component mount initialisation before applying edit-specific prefill logic
- guard against missing purchase return models to avoid runtime errors

## Testing
- `php artisan test` *(fails: vendor autoloader missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f1c001c483269cc2c6e1593528d0