### PR TITLE
Normalize purchase return settlement type labels and polish details table

### DIFF
--- a/app/Livewire/PurchaseReturn/PurchaseReturnSettlementForm.php
+++ b/app/Livewire/PurchaseReturn/PurchaseReturnSettlementForm.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use Livewire\Component;
 use Livewire\WithFileUploads;
@@ -57,7 +58,9 @@ class PurchaseReturnSettlementForm extends Component
         ])->findOrFail($this->purchaseReturnId);
 
         $this->isReadOnly = ! empty($this->purchaseReturn->return_type);
-        $this->return_type = $this->purchaseReturn->return_type ?? '';
+        $this->return_type = $this->purchaseReturn->return_type
+            ? Str::lower($this->purchaseReturn->return_type)
+            : '';
         $this->replacement_goods = [];
 
         if ($this->purchaseReturn->goods->isNotEmpty()) {
@@ -319,6 +322,9 @@ class PurchaseReturnSettlementForm extends Component
             'total' => $this->settlementTotal(),
             'creditAmount' => $this->calculateCreditAmount(),
             'isReadOnly' => $this->isReadOnly,
+            'displayReturnType' => $this->return_type !== ''
+                ? Str::of($this->return_type)->lower()->ucfirst()
+                : '',
         ]);
     }
 }

--- a/resources/views/livewire/purchase-return/purchase-return-settlement-form.blade.php
+++ b/resources/views/livewire/purchase-return/purchase-return-settlement-form.blade.php
@@ -42,7 +42,7 @@
                 @if($isReadOnly)
                     <div class="alert alert-success d-flex align-items-center gap-2 mt-3 mb-0" role="alert">
                         <i class="bi bi-check-circle-fill"></i>
-                        <span>Metode penyelesaian sudah ditetapkan sebagai <strong>{{ ucfirst($purchaseReturn->return_type) }}</strong>.</span>
+                        <span>Metode penyelesaian sudah ditetapkan sebagai <strong>{{ $displayReturnType }}</strong>.</span>
                     </div>
                 @endif
             </div>
@@ -190,8 +190,8 @@
             </div>
             <div class="card-body p-0">
                 <div class="table-responsive">
-                    <table class="table table-sm table-striped mb-0">
-                        <thead class="table-light">
+                    <table class="table table-hover table-sm align-middle mb-0">
+                        <thead class="table-light text-muted text-uppercase small">
                             <tr>
                                 <th>Produk</th>
                                 <th class="text-center">Jumlah</th>
@@ -200,18 +200,32 @@
                             </tr>
                         </thead>
                         <tbody>
-                            @foreach($details as $detail)
+                            @forelse($details as $detail)
                                 <tr>
                                     <td>
                                         <div class="fw-semibold">{{ $detail->product_name }}</div>
-                                        <small class="text-muted">{{ $detail->product_code }}</small>
+                                        @if($detail->product_code)
+                                            <span class="badge bg-light text-secondary border">{{ $detail->product_code }}</span>
+                                        @endif
                                     </td>
-                                    <td class="text-center">{{ $detail->quantity }}</td>
+                                    <td class="text-center">
+                                        <span class="fw-semibold">{{ $detail->quantity }}</span>
+                                    </td>
                                     <td class="text-end">{{ format_currency($detail->unit_price) }}</td>
                                     <td class="text-end">{{ format_currency($detail->sub_total) }}</td>
                                 </tr>
-                            @endforeach
+                            @empty
+                                <tr>
+                                    <td colspan="4" class="text-center text-muted py-4">Tidak ada detail produk retur.</td>
+                                </tr>
+                            @endforelse
                         </tbody>
+                        <tfoot class="table-light">
+                            <tr>
+                                <th colspan="3" class="text-end text-muted">Total Retur</th>
+                                <th class="text-end fw-semibold">{{ format_currency($total) }}</th>
+                            </tr>
+                        </tfoot>
                     </table>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- normalize the purchase return settlement type to lowercase when loading saved data
- provide a display-friendly return type label for the settlement form view
- update the settlement view to use the normalized value for state and display the friendly label
- refresh the return detail table styling with improved badges, totals, and empty-state handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0f4fb42848326bea27c381b860f0c