### PR TITLE
Use decimal monetary storage for sales flows

### DIFF
--- a/Modules/Sale/Database/Migrations/2025_04_10_000000_downscale_sale_amounts.php
+++ b/Modules/Sale/Database/Migrations/2025_04_10_000000_downscale_sale_amounts.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('sale_details', function (Blueprint $table) {
+            $table->decimal('price', 15, 2)->change();
+            $table->decimal('unit_price', 15, 2)->change();
+            $table->decimal('sub_total', 15, 2)->change();
+            $table->decimal('product_discount_amount', 15, 2)->change();
+            $table->decimal('product_tax_amount', 15, 2)->change();
+        });
+
+        Schema::table('sale_bundle_items', function (Blueprint $table) {
+            $table->decimal('price', 15, 2)->change();
+            $table->decimal('sub_total', 15, 2)->change();
+        });
+
+        DB::transaction(function () {
+            DB::statement('UPDATE sales SET tax_amount = ROUND(tax_amount / 100, 2), discount_amount = ROUND(discount_amount / 100, 2), shipping_amount = ROUND(shipping_amount / 100, 2), total_amount = ROUND(total_amount / 100, 2), paid_amount = ROUND(paid_amount / 100, 2), due_amount = ROUND(due_amount / 100, 2)');
+            DB::statement('UPDATE sale_payments SET amount = ROUND(amount / 100, 2)');
+            DB::statement('UPDATE sale_details SET price = ROUND(price / 100, 2), unit_price = ROUND(unit_price / 100, 2), sub_total = ROUND(sub_total / 100, 2), product_discount_amount = ROUND(product_discount_amount / 100, 2), product_tax_amount = ROUND(product_tax_amount / 100, 2)');
+            DB::statement('UPDATE sale_bundle_items SET price = ROUND(price / 100, 2), sub_total = ROUND(sub_total / 100, 2)');
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            DB::statement('UPDATE sale_bundle_items SET price = price * 100, sub_total = sub_total * 100');
+            DB::statement('UPDATE sale_details SET price = price * 100, unit_price = unit_price * 100, sub_total = sub_total * 100, product_discount_amount = product_discount_amount * 100, product_tax_amount = product_tax_amount * 100');
+            DB::statement('UPDATE sale_payments SET amount = amount * 100');
+            DB::statement('UPDATE sales SET tax_amount = tax_amount * 100, discount_amount = discount_amount * 100, shipping_amount = shipping_amount * 100, total_amount = total_amount * 100, paid_amount = paid_amount * 100, due_amount = due_amount * 100');
+        });
+
+        Schema::table('sale_bundle_items', function (Blueprint $table) {
+            $table->integer('price')->change();
+            $table->integer('sub_total')->change();
+        });
+
+        Schema::table('sale_details', function (Blueprint $table) {
+            $table->integer('price')->change();
+            $table->integer('unit_price')->change();
+            $table->integer('sub_total')->change();
+            $table->integer('product_discount_amount')->change();
+            $table->integer('product_tax_amount')->change();
+        });
+    }
+};

--- a/Modules/Sale/Entities/Sale.php
+++ b/Modules/Sale/Entities/Sale.php
@@ -12,6 +12,15 @@ class Sale extends BaseModel
 {
     protected $guarded = [];
 
+    protected $casts = [
+        'tax_amount' => 'decimal:2',
+        'discount_amount' => 'decimal:2',
+        'shipping_amount' => 'decimal:2',
+        'total_amount' => 'decimal:2',
+        'paid_amount' => 'decimal:2',
+        'due_amount' => 'decimal:2',
+    ];
+
     const STATUS_DRAFTED = 'DRAFTED';
     const STATUS_WAITING_APPROVAL = 'WAITING_APPROVAL';
     const STATUS_APPROVED = 'APPROVED';

--- a/Modules/Sale/Entities/SaleBundleItem.php
+++ b/Modules/Sale/Entities/SaleBundleItem.php
@@ -10,6 +10,11 @@ class SaleBundleItem extends BaseModel
 {
     protected $guarded = [];
 
+    protected $casts = [
+        'price' => 'decimal:2',
+        'sub_total' => 'decimal:2',
+    ];
+
     /**
      * Relationship to the sale detail this bundle item belongs to.
      */

--- a/Modules/Sale/Entities/SaleDetails.php
+++ b/Modules/Sale/Entities/SaleDetails.php
@@ -12,6 +12,14 @@ class SaleDetails extends BaseModel
 {
     protected $guarded = [];
 
+    protected $casts = [
+        'price' => 'decimal:2',
+        'unit_price' => 'decimal:2',
+        'sub_total' => 'decimal:2',
+        'product_discount_amount' => 'decimal:2',
+        'product_tax_amount' => 'decimal:2',
+    ];
+
     protected $with = ['product'];
 
     public function product(): BelongsTo

--- a/Modules/Sale/Entities/SalePayment.php
+++ b/Modules/Sale/Entities/SalePayment.php
@@ -15,19 +15,14 @@ class SalePayment extends BaseModel implements HasMedia
 
     protected $guarded = [];
 
+    protected $casts = [
+        'amount' => 'decimal:2',
+        'date' => 'date',
+    ];
+
     public function sale(): BelongsTo
     {
         return $this->belongsTo(Sale::class, 'sale_id', 'id');
-    }
-
-    public function setAmountAttribute($value): void
-    {
-        $this->attributes['amount'] = $value * 100;
-    }
-
-    public function getAmountAttribute($value): float|int
-    {
-        return $value / 100;
     }
 
     public function getDateAttribute($value): string

--- a/Modules/Sale/Http/Controllers/SaleController.php
+++ b/Modules/Sale/Http/Controllers/SaleController.php
@@ -319,9 +319,12 @@ class SaleController extends Controller
         abort_if(Gate::denies('sales.edit'), 403);
         DB::transaction(function () use ($request, $sale) {
 
-            $due_amount = $request->total_amount - $request->paid_amount;
+            $due_amount = round((float) $request->total_amount - (float) $request->paid_amount, 2);
+            $due_amount = max($due_amount, 0);
 
-            if ($due_amount == $request->total_amount) {
+            $total_amount = round((float) $request->total_amount, 2);
+
+            if (round($due_amount, 2) >= $total_amount) {
                 $payment_status = 'Unpaid';
             } elseif ($due_amount > 0) {
                 $payment_status = 'Partial';
@@ -346,16 +349,16 @@ class SaleController extends Controller
                 'customer_name' => Customer::findOrFail($request->customer_id)->customer_name,
                 'tax_percentage' => $request->tax_percentage,
                 'discount_percentage' => $request->discount_percentage,
-                'shipping_amount' => $request->shipping_amount * 100,
-                'paid_amount' => $request->paid_amount * 100,
-                'total_amount' => $request->total_amount * 100,
-                'due_amount' => $due_amount * 100,
+                'shipping_amount' => round((float) $request->shipping_amount, 2),
+                'paid_amount' => round((float) $request->paid_amount, 2),
+                'total_amount' => $total_amount,
+                'due_amount' => $due_amount,
                 'status' => $request->status,
                 'payment_status' => $payment_status,
                 'payment_method' => $request->payment_method,
                 'note' => $request->note,
-                'tax_amount' => Cart::instance('sale')->tax() * 100,
-                'discount_amount' => Cart::instance('sale')->discount() * 100,
+                'tax_amount' => round((float) Cart::instance('sale')->tax(), 2),
+                'discount_amount' => round((float) Cart::instance('sale')->discount(), 2),
             ]);
 
             foreach (Cart::instance('sale')->content() as $cart_item) {
@@ -365,12 +368,12 @@ class SaleController extends Controller
                     'product_name' => $cart_item->name,
                     'product_code' => $cart_item->options->code,
                     'quantity' => $cart_item->qty,
-                    'price' => $cart_item->price * 100,
-                    'unit_price' => $cart_item->options->unit_price * 100,
-                    'sub_total' => $cart_item->options->sub_total * 100,
-                    'product_discount_amount' => $cart_item->options->product_discount * 100,
+                    'price' => round((float) $cart_item->price, 2),
+                    'unit_price' => round((float) $cart_item->options->unit_price, 2),
+                    'sub_total' => round((float) $cart_item->options->sub_total, 2),
+                    'product_discount_amount' => round((float) $cart_item->options->product_discount, 2),
                     'product_discount_type' => $cart_item->options->product_discount_type,
-                    'product_tax_amount' => $cart_item->options->product_tax * 100,
+                    'product_tax_amount' => round((float) $cart_item->options->product_tax, 2),
                 ]);
 
                 if ($request->status == 'Shipped' || $request->status == 'Completed') {

--- a/tests/Feature/SaleMonetaryValuesTest.php
+++ b/tests/Feature/SaleMonetaryValuesTest.php
@@ -1,0 +1,369 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\CheckUserRoleForSetting;
+use App\Models\User;
+use Gloudemans\Shoppingcart\Facades\Cart;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Session;
+use Modules\People\Entities\Customer;
+use Modules\Product\Entities\Category;
+use Modules\Product\Entities\Product;
+use Modules\Purchase\Entities\PaymentTerm;
+use Modules\Sale\Entities\Sale;
+use Modules\Sale\Entities\SaleDetails;
+use Modules\Sale\Entities\SalePayment;
+use Modules\Setting\Entities\ChartOfAccount;
+use Modules\Setting\Entities\Currency;
+use Modules\Setting\Entities\PaymentMethod;
+use Modules\Setting\Entities\Setting;
+use Modules\Setting\Entities\Unit;
+use Tests\TestCase;
+
+class SaleMonetaryValuesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected Setting $setting;
+    protected Customer $customer;
+    protected Product $product;
+    protected PaymentTerm $paymentTerm;
+    protected PaymentMethod $paymentMethod;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Gate::before(function () {
+            return true;
+        });
+
+        $this->withoutMiddleware(CheckUserRoleForSetting::class);
+
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $currency = Currency::create([
+            'currency_name' => 'Rupiah',
+            'code' => 'IDR',
+            'symbol' => 'Rp',
+            'thousand_separator' => '.',
+            'decimal_separator' => ',',
+            'exchange_rate' => 1,
+        ]);
+
+        $this->setting = Setting::create([
+            'company_name' => 'Test Co',
+            'company_email' => 'company@example.com',
+            'company_phone' => '123456789',
+            'site_logo' => null,
+            'default_currency_id' => $currency->id,
+            'default_currency_position' => 'left',
+            'notification_email' => 'notify@example.com',
+            'footer_text' => 'Footer',
+            'company_address' => 'Address',
+        ]);
+
+        Session::put('setting_id', $this->setting->id);
+
+        $unit = Unit::create([
+            'name' => 'PCS',
+            'short_name' => 'PCS',
+            'operator' => '*',
+            'operation_value' => 1,
+            'setting_id' => $this->setting->id,
+        ]);
+
+        $this->paymentTerm = PaymentTerm::create([
+            'setting_id' => $this->setting->id,
+            'name' => 'NET 10',
+            'longevity' => 10,
+        ]);
+
+        $this->customer = Customer::create([
+            'customer_name' => 'Test Customer',
+            'customer_email' => 'customer@example.com',
+            'customer_phone' => '0800000000',
+            'city' => 'Jakarta',
+            'country' => 'Indonesia',
+            'address' => 'Street 1',
+            'company_name' => 'Customer Co',
+            'contact_name' => 'Contact',
+            'billing_address' => 'Billing',
+            'shipping_address' => 'Shipping',
+            'setting_id' => $this->setting->id,
+            'payment_term_id' => $this->paymentTerm->id,
+        ]);
+
+        $category = Category::create([
+            'category_code' => 'CAT001',
+            'category_name' => 'Category',
+        ]);
+
+        $this->product = Product::create([
+            'setting_id' => $this->setting->id,
+            'category_id' => $category->id,
+            'product_name' => 'Sample Product',
+            'product_code' => 'PRD001',
+            'product_barcode_symbology' => null,
+            'product_quantity' => 100,
+            'product_cost' => 5.50,
+            'product_price' => 15.75,
+            'product_unit' => 'PCS',
+            'product_stock_alert' => 5,
+            'product_order_tax' => 0,
+            'product_tax_type' => 0,
+            'stock_managed' => true,
+            'unit_id' => $unit->id,
+            'base_unit_id' => $unit->id,
+            'sale_price' => 15.75,
+            'tier_1_price' => 15.75,
+            'tier_2_price' => 15.75,
+        ]);
+
+        $chartOfAccount = ChartOfAccount::create([
+            'name' => 'Kas',
+            'account_number' => '1000',
+            'category' => 'Kas & Bank',
+            'parent_account_id' => null,
+            'tax_id' => null,
+            'description' => null,
+            'setting_id' => $this->setting->id,
+        ]);
+
+        $this->paymentMethod = PaymentMethod::create([
+            'name' => 'Cash',
+            'coa_id' => $chartOfAccount->id,
+            'setting_id' => $this->setting->id,
+        ]);
+    }
+
+    protected function addCartItem(float $price, float $discount, float $taxAmount, float $subTotal): void
+    {
+        Cart::instance('sale')->destroy();
+
+        Cart::instance('sale')->add([
+            'id' => $this->product->id,
+            'name' => $this->product->product_name,
+            'qty' => 2,
+            'price' => $price,
+            'weight' => 1,
+            'options' => [
+                'product_id' => $this->product->id,
+                'code' => $this->product->product_code,
+                'unit_price' => $price,
+                'product_discount' => $discount,
+                'product_discount_type' => 'fixed',
+                'product_tax' => $taxAmount,
+                'sub_total' => $subTotal,
+                'sub_total_before_tax' => $subTotal - $taxAmount,
+                'bundle_items' => [],
+                'stock' => 100,
+            ],
+        ]);
+    }
+
+    public function test_sale_store_persists_decimal_amounts(): void
+    {
+        $this->addCartItem(24.80, 1.20, 0.80, 48.40);
+
+        $response = $this->post(route('sales.store'), [
+            'customer_id' => $this->customer->id,
+            'reference' => 'SL-TEST',
+            'date' => '2024-04-01',
+            'due_date' => '2024-04-11',
+            'tax_id' => null,
+            'discount_percentage' => 0,
+            'shipping_amount' => 12.35,
+            'total_amount' => 60.75,
+            'payment_term_id' => $this->paymentTerm->id,
+            'note' => 'Store decimals',
+            'is_tax_included' => false,
+        ]);
+
+        $response->assertRedirect(route('sales.index'));
+
+        $sale = Sale::latest('id')->with('saleDetails')->first();
+
+        $this->assertNotNull($sale);
+        $this->assertEquals(12.35, (float) $sale->shipping_amount);
+        $this->assertEquals(60.75, (float) $sale->total_amount);
+        $this->assertEquals(60.75, (float) $sale->due_amount);
+
+        $detail = $sale->saleDetails->first();
+        $this->assertEquals(24.80, (float) $detail->unit_price);
+        $this->assertEquals(24.80, (float) $detail->price);
+        $this->assertEquals(48.40, (float) $detail->sub_total);
+        $this->assertEquals(1.20, (float) $detail->product_discount_amount);
+        $this->assertEquals(0.80, (float) $detail->product_tax_amount);
+    }
+
+    public function test_sale_update_persists_decimal_amounts(): void
+    {
+        $sale = Sale::create([
+            'date' => '2024-03-01',
+            'due_date' => '2024-03-11',
+            'customer_id' => $this->customer->id,
+            'customer_name' => $this->customer->customer_name,
+            'tax_percentage' => 0,
+            'tax_amount' => 0,
+            'discount_percentage' => 0,
+            'discount_amount' => 0,
+            'shipping_amount' => 5.25,
+            'total_amount' => 40.00,
+            'paid_amount' => 10.00,
+            'due_amount' => 30.00,
+            'status' => 'Pending',
+            'payment_status' => 'Partial',
+            'payment_method' => 'Cash',
+            'note' => null,
+            'setting_id' => $this->setting->id,
+            'payment_term_id' => $this->paymentTerm->id,
+            'is_tax_included' => false,
+        ]);
+
+        SaleDetails::create([
+            'sale_id' => $sale->id,
+            'product_id' => $this->product->id,
+            'product_name' => $this->product->product_name,
+            'product_code' => $this->product->product_code,
+            'quantity' => 1,
+            'price' => 20.00,
+            'unit_price' => 20.00,
+            'sub_total' => 20.00,
+            'product_discount_amount' => 0.00,
+            'product_discount_type' => 'fixed',
+            'product_tax_amount' => 0.00,
+        ]);
+
+        $this->addCartItem(25.45, 1.50, 0.75, 49.40);
+
+        $response = $this->put(route('sales.update', $sale), [
+            'customer_id' => $this->customer->id,
+            'reference' => $sale->reference,
+            'tax_percentage' => 5,
+            'discount_percentage' => 0,
+            'shipping_amount' => 11.65,
+            'total_amount' => 61.50,
+            'paid_amount' => 21.40,
+            'status' => 'Pending',
+            'payment_method' => 'Cash',
+            'note' => 'Update decimals',
+        ]);
+
+        $response->assertRedirect(route('sales.index'));
+
+        $sale->refresh();
+        $this->assertEquals(11.65, (float) $sale->shipping_amount);
+        $this->assertEquals(61.50, (float) $sale->total_amount);
+        $this->assertEquals(40.10, (float) $sale->due_amount);
+        $this->assertEquals(21.40, (float) $sale->paid_amount);
+
+        $detail = $sale->saleDetails()->first();
+        $this->assertEquals(25.45, (float) $detail->price);
+        $this->assertEquals(25.45, (float) $detail->unit_price);
+        $this->assertEquals(49.40, (float) $detail->sub_total);
+        $this->assertEquals(1.50, (float) $detail->product_discount_amount);
+        $this->assertEquals(0.75, (float) $detail->product_tax_amount);
+    }
+
+    public function test_sale_payment_store_updates_sale_totals(): void
+    {
+        $sale = Sale::create([
+            'date' => '2024-02-01',
+            'due_date' => '2024-02-11',
+            'customer_id' => $this->customer->id,
+            'customer_name' => $this->customer->customer_name,
+            'tax_percentage' => 0,
+            'tax_amount' => 0,
+            'discount_percentage' => 0,
+            'discount_amount' => 0,
+            'shipping_amount' => 0,
+            'total_amount' => 120.00,
+            'paid_amount' => 40.00,
+            'due_amount' => 80.00,
+            'status' => 'Pending',
+            'payment_status' => 'Partial',
+            'payment_method' => 'Cash',
+            'note' => null,
+            'setting_id' => $this->setting->id,
+            'payment_term_id' => $this->paymentTerm->id,
+            'is_tax_included' => false,
+        ]);
+
+        $response = $this->post(route('sale-payments.store'), [
+            'date' => '2024-02-15',
+            'reference' => 'PAY-01',
+            'amount' => 30.75,
+            'note' => 'Store payment',
+            'sale_id' => $sale->id,
+            'payment_method_id' => $this->paymentMethod->id,
+        ]);
+
+        $response->assertRedirect(route('sales.index'));
+
+        $sale->refresh();
+        $payment = SalePayment::latest('id')->first();
+
+        $this->assertEquals(30.75, (float) $payment->amount);
+        $this->assertEquals(70.75, (float) $sale->paid_amount);
+        $this->assertEquals(49.25, (float) $sale->due_amount);
+        $this->assertEquals('Partial', $sale->payment_status);
+    }
+
+    public function test_sale_payment_update_adjusts_sale_totals(): void
+    {
+        $sale = Sale::create([
+            'date' => '2024-01-05',
+            'due_date' => '2024-01-15',
+            'customer_id' => $this->customer->id,
+            'customer_name' => $this->customer->customer_name,
+            'tax_percentage' => 0,
+            'tax_amount' => 0,
+            'discount_percentage' => 0,
+            'discount_amount' => 0,
+            'shipping_amount' => 0,
+            'total_amount' => 100.00,
+            'paid_amount' => 20.00,
+            'due_amount' => 80.00,
+            'status' => 'Pending',
+            'payment_status' => 'Partial',
+            'payment_method' => 'Cash',
+            'note' => null,
+            'setting_id' => $this->setting->id,
+            'payment_term_id' => $this->paymentTerm->id,
+            'is_tax_included' => false,
+        ]);
+
+        $payment = SalePayment::create([
+            'sale_id' => $sale->id,
+            'date' => '2024-01-06',
+            'reference' => 'PAY-02',
+            'amount' => 20.00,
+            'payment_method_id' => $this->paymentMethod->id,
+            'payment_method' => 'Cash',
+            'note' => null,
+        ]);
+
+        $response = $this->patch(route('sale-payments.update', $payment), [
+            'date' => '2024-01-07',
+            'reference' => 'PAY-02',
+            'amount' => 35.50,
+            'note' => 'Update payment',
+            'sale_id' => $sale->id,
+            'payment_method_id' => $this->paymentMethod->id,
+        ]);
+
+        $response->assertRedirect(route('sales.index'));
+
+        $sale->refresh();
+        $payment->refresh();
+
+        $this->assertEquals(35.50, (float) $payment->amount);
+        $this->assertEquals(35.50, (float) $sale->paid_amount);
+        $this->assertEquals(64.50, (float) $sale->due_amount);
+        $this->assertEquals('Partial', $sale->payment_status);
+    }
+}


### PR DESCRIPTION
## Summary
- persist sales, sale details, and payments using native decimal values instead of multiplying by 100
- add a backfill migration that converts existing cent-based data to true decimals
- cover sale creation/update and payment create/update with regression tests to guard stored figures

## Testing
- `php artisan test` *(fails: project dependencies require PHP ≤8.3; container runs PHP 8.4.12)*

------
https://chatgpt.com/codex/tasks/task_e_68e10e83d2f88326af9a22d2be423bc5