### PR TITLE
Make sales master data global across settings

### DIFF
--- a/Modules/Product/Jobs/ProcessProductImportChunk.php
+++ b/Modules/Product/Jobs/ProcessProductImportChunk.php
@@ -125,7 +125,7 @@ class ProcessProductImportChunk implements ShouldQueue
                         return null;
                     };
 
-                    $firstOrCreateTax = function (?string $name) use (&$cacheTax, $settingIdForCreations, $parseTaxPercent) {
+                    $firstOrCreateTax = function (?string $name) use (&$cacheTax, $parseTaxPercent) {
                         $n = trim((string) $name);
                         if ($n === '') return null;
                         $k = mb_strtolower($n);
@@ -136,7 +136,6 @@ class ProcessProductImportChunk implements ShouldQueue
                             $row = Tax::create([
                                 'name'       => $n,
                                 'value'      => $parseTaxPercent($n) ?? 0.0,
-                                'setting_id' => $settingIdForCreations,
                             ]);
                         }
                         return $cacheTax[$k] = (int) $row->id;

--- a/Modules/Purchase/Database/Migrations/2024_11_27_154759_add_payment_terms_table.php
+++ b/Modules/Purchase/Database/Migrations/2024_11_27_154759_add_payment_terms_table.php
@@ -16,13 +16,9 @@ return new class extends Migration
     {
         Schema::create('payment_terms', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->unsignedBigInteger('setting_id'); // Foreign key to settings table
             $table->string('name');
             $table->integer('longevity')->default(0);
             $table->timestamps();
-
-            // Define the foreign key constraint
-            $table->foreign('setting_id')->references('id')->on('settings')->onDelete('cascade');
         });
 
         // Seed the table with the provided data
@@ -44,27 +40,19 @@ return new class extends Migration
      */
     private function seedPaymentTerms(): void
     {
-        // Get the first setting_id from the settings table
-        $firstSettingId = DB::table('settings')->value('id');
-
-        if (!$firstSettingId) {
-            // If no settings are available, exit the seed process
-            return;
-        }
-
         $paymentTerms = [
-            ['id' => 858231, 'setting_id' => $firstSettingId, 'name' => 'Net 30', 'longevity' => 30],
-            ['id' => 858232, 'setting_id' => $firstSettingId, 'name' => 'Cash on Delivery', 'longevity' => 0],
-            ['id' => 858233, 'setting_id' => $firstSettingId, 'name' => 'Net 15', 'longevity' => 15],
-            ['id' => 858234, 'setting_id' => $firstSettingId, 'name' => 'Net 60', 'longevity' => 60],
-            ['id' => 858235, 'setting_id' => $firstSettingId, 'name' => 'Custom', 'longevity' => 0],
-            ['id' => 873940, 'setting_id' => $firstSettingId, 'name' => 'Term 14 hari', 'longevity' => 14],
-            ['id' => 898556, 'setting_id' => $firstSettingId, 'name' => 'net 21', 'longevity' => 21],
-            ['id' => 1188378, 'setting_id' => $firstSettingId, 'name' => 'NET 7 HARI', 'longevity' => 7],
-            ['id' => 1726493, 'setting_id' => $firstSettingId, 'name' => '45 HR', 'longevity' => 45],
-            ['id' => 2353345, 'setting_id' => $firstSettingId, 'name' => '10 HARI', 'longevity' => 10],
-            ['id' => 2627421, 'setting_id' => $firstSettingId, 'name' => '24 HR', 'longevity' => 24],
-            ['id' => 2917154, 'setting_id' => $firstSettingId, 'name' => '28HR', 'longevity' => 28],
+            ['id' => 858231, 'name' => 'Net 30', 'longevity' => 30],
+            ['id' => 858232, 'name' => 'Cash on Delivery', 'longevity' => 0],
+            ['id' => 858233, 'name' => 'Net 15', 'longevity' => 15],
+            ['id' => 858234, 'name' => 'Net 60', 'longevity' => 60],
+            ['id' => 858235, 'name' => 'Custom', 'longevity' => 0],
+            ['id' => 873940, 'name' => 'Term 14 hari', 'longevity' => 14],
+            ['id' => 898556, 'name' => 'net 21', 'longevity' => 21],
+            ['id' => 1188378, 'name' => 'NET 7 HARI', 'longevity' => 7],
+            ['id' => 1726493, 'name' => '45 HR', 'longevity' => 45],
+            ['id' => 2353345, 'name' => '10 HARI', 'longevity' => 10],
+            ['id' => 2627421, 'name' => '24 HR', 'longevity' => 24],
+            ['id' => 2917154, 'name' => '28HR', 'longevity' => 28],
         ];
 
         DB::table('payment_terms')->insert($paymentTerms);

--- a/Modules/Purchase/Entities/PaymentTerm.php
+++ b/Modules/Purchase/Entities/PaymentTerm.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Modules\People\Entities\Customer;
 use Modules\People\Entities\Supplier;
-use Modules\Setting\Entities\Setting;
 
 class PaymentTerm extends BaseModel
 {
@@ -26,18 +25,9 @@ class PaymentTerm extends BaseModel
      */
     protected $fillable = [
         'id',
-        'setting_id',
         'name',
         'longevity',
     ];
-
-    /**
-     * Get the setting associated with the payment term.
-     */
-    public function setting(): BelongsTo
-    {
-        return $this->belongsTo(Setting::class, 'setting_id', 'id');
-    }
     public function customers(): HasMany
     {
         return $this->hasMany(Customer::class, 'payment_term_id', 'id');

--- a/Modules/Purchase/Http/Controllers/PurchasePaymentsController.php
+++ b/Modules/Purchase/Http/Controllers/PurchasePaymentsController.php
@@ -31,7 +31,7 @@ class PurchasePaymentsController extends Controller
         $purchase = Purchase::findOrFail($purchase_id);
         $this->ensurePurchaseBelongsToCurrentSetting($purchase);
 
-        $payment_methods = PaymentMethod::where('setting_id', session('setting_id'))->get();
+        $payment_methods = PaymentMethod::all();
         return view('purchase::payments.create', compact('purchase', 'payment_methods'));
     }
 
@@ -48,8 +48,8 @@ class PurchasePaymentsController extends Controller
             'reference' => 'required|string|max:255',
             'amount' => 'required|numeric|max:' . $purchase->due_amount,
             'note' => 'nullable|string|max:1000',
-            'purchase_id' => 'required',
-            'payment_method_id' => 'required|string|max:255',
+            'purchase_id' => 'required|integer|exists:purchases,id',
+            'payment_method_id' => 'required|integer|exists:payment_methods,id',
             'attachment' => 'nullable|string', // Validation for file upload
         ], [
             'amount.max' => 'The payment amount cannot be greater than the due amount.'

--- a/Modules/Sale/Http/Controllers/SaleController.php
+++ b/Modules/Sale/Http/Controllers/SaleController.php
@@ -54,12 +54,8 @@ class SaleController extends Controller
             Cart::instance('sale')->destroy();
         }
 
-        // Retrieve the current setting_id from the session
-        $setting_id = session('setting_id');
-
-        // Filter PaymentTerms by the setting_id
-        $paymentTerms = PaymentTerm::where('setting_id', $setting_id)->get();
-        $customers = Customer::where('setting_id', $setting_id)->get();
+        $paymentTerms = PaymentTerm::all();
+        $customers = Customer::all();
 
         return view('sale::create', compact('paymentTerms', 'customers'));
     }

--- a/Modules/Sale/Http/Controllers/SalePaymentsController.php
+++ b/Modules/Sale/Http/Controllers/SalePaymentsController.php
@@ -27,8 +27,7 @@ class SalePaymentsController extends Controller
         abort_if(Gate::denies('salePayments.create'), 403);
 
         $sale = Sale::findOrFail($sale_id);
-        // Retrieve payment methods for the current setting.
-        $payment_methods = PaymentMethod::where('setting_id', session('setting_id'))->get();
+        $payment_methods = PaymentMethod::all();
 
         return view('sale::payments.create', compact('sale', 'payment_methods'));
     }
@@ -44,7 +43,7 @@ class SalePaymentsController extends Controller
             'reference'          => 'required|string|max:255',
             'amount'             => 'required|numeric|max:' . (float) $sale->due_amount,
             'note'               => 'nullable|string|max:1000',
-            'sale_id'            => 'required',
+            'sale_id'            => 'required|integer|exists:sales,id',
             'payment_method_id'  => 'required|integer|exists:payment_methods,id',
             'attachment'         => 'nullable|string', // file upload via Dropzone returns file name
         ], [
@@ -98,8 +97,7 @@ class SalePaymentsController extends Controller
         abort_if(Gate::denies('salePayments.edit'), 403);
 
         $sale = Sale::findOrFail($sale_id);
-        // Retrieve payment methods for the current setting.
-        $payment_methods = PaymentMethod::where('setting_id', session('setting_id'))->get();
+        $payment_methods = PaymentMethod::all();
 
         return view('sale::payments.edit', compact('salePayment', 'sale', 'payment_methods'));
     }
@@ -115,7 +113,7 @@ class SalePaymentsController extends Controller
             'reference'          => 'required|string|max:255',
             'amount'             => 'required|numeric|max:' . ((float) $sale->due_amount + (float) $salePayment->amount),
             'note'               => 'nullable|string|max:1000',
-            'sale_id'            => 'required',
+            'sale_id'            => 'required|integer|exists:sales,id',
             'payment_method_id'  => 'required|integer|exists:payment_methods,id',
             // Attachment is optional on update.
             'attachment'         => 'nullable|string',

--- a/Modules/Sale/Tests/Feature/SaleRequestAuthorizationTest.php
+++ b/Modules/Sale/Tests/Feature/SaleRequestAuthorizationTest.php
@@ -48,7 +48,6 @@ class SaleRequestAuthorizationTest extends TestCase
     private function createPaymentTerm(Setting $setting): PaymentTerm
     {
         return PaymentTerm::create([
-            'setting_id' => $setting->id,
             'name' => 'Net 30',
             'longevity' => 30,
         ]);

--- a/Modules/Setting/Database/Migrations/2024_09_13_230003_add_taxes_table.php
+++ b/Modules/Setting/Database/Migrations/2024_09_13_230003_add_taxes_table.php
@@ -13,12 +13,9 @@ return new class extends Migration
     {
         Schema::create('taxes', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('setting_id');
             $table->string('name');
             $table->decimal('value');
             $table->timestamps();
-
-            $table->foreign('setting_id')->references('id')->on('settings')->onDelete('cascade');
         });
     }
 

--- a/Modules/Setting/Database/Migrations/2025_01_22_190525_create_payment_methods_table.php
+++ b/Modules/Setting/Database/Migrations/2025_01_22_190525_create_payment_methods_table.php
@@ -12,7 +12,6 @@ return new class extends Migration
             $table->id();
             $table->string('name'); // Payment method name
             $table->unsignedBigInteger('coa_id'); // Chart of Accounts ID
-            $table->unsignedBigInteger('setting_id'); // Auto-filled from session
             $table->timestamps();
 
             // Foreign key constraints

--- a/Modules/Setting/Entities/PaymentMethod.php
+++ b/Modules/Setting/Entities/PaymentMethod.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class PaymentMethod extends BaseModel
 {
-    protected $fillable = ['name', 'coa_id', 'setting_id'];
+    protected $fillable = ['name', 'coa_id'];
 
     public function chartOfAccount(): BelongsTo
     {

--- a/Modules/Setting/Entities/Setting.php
+++ b/Modules/Setting/Entities/Setting.php
@@ -6,9 +6,7 @@ use App\Models\BaseModel;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Modules\Currency\Entities\Currency;
-use Modules\Purchase\Entities\PaymentTerm;
 
 class Setting extends BaseModel
 {
@@ -27,8 +25,4 @@ class Setting extends BaseModel
             ->withPivot('role_id');
     }
 
-    public function paymentTerms(): HasMany
-    {
-        return $this->hasMany(PaymentTerm::class, 'setting_id', 'id');
-    }
 }

--- a/Modules/Setting/Entities/Tax.php
+++ b/Modules/Setting/Entities/Tax.php
@@ -3,17 +3,7 @@
 namespace Modules\Setting\Entities;
 
 use App\Models\BaseModel;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-
 class Tax extends BaseModel
 {
     protected $guarded = [];
-
-    /**
-     * Get the setting (business) that owns the location.
-     */
-    public function setting(): BelongsTo
-    {
-        return $this->belongsTo(Setting::class);
-    }
 }

--- a/Modules/Setting/Http/Controllers/PaymentMethodController.php
+++ b/Modules/Setting/Http/Controllers/PaymentMethodController.php
@@ -42,7 +42,6 @@ class PaymentMethodController extends Controller
         PaymentMethod::create([
             'name' => $request->name,
             'coa_id' => $request->coa_id,
-            'setting_id' => session('setting_id'), // Autofill setting_id from session
         ]);
 
         toast('Payment method created successfully!', 'success');

--- a/Modules/Setting/Http/Controllers/PaymentTermController.php
+++ b/Modules/Setting/Http/Controllers/PaymentTermController.php
@@ -47,7 +47,7 @@ class PaymentTermController extends Controller
         abort_if(Gate::denies('paymentTerms.create'), 403);
 
         $request->validate([
-            'name'      => 'required|string|max:255|unique:payment_terms,name,NULL,id,setting_id,' . session('setting_id'),
+            'name'      => 'required|string|max:255|unique:payment_terms,name',
             'longevity' => 'required|integer|min:0', // allow 0
         ], [
             'longevity.min' => 'Tempo tidak boleh lebih kecil dari 0',
@@ -57,7 +57,6 @@ class PaymentTermController extends Controller
         PaymentTerm::create([
             'name'       => $request->name,
             'longevity'  => (int) $request->longevity,
-            'setting_id' => session('setting_id'),
         ]);
 
         toast('Term Pembayaran Berhasil ditambahkan!', 'success');
@@ -88,7 +87,7 @@ class PaymentTermController extends Controller
         abort_if(Gate::denies('paymentTerms.edit'), 403);
 
         $request->validate([
-            'name'      => 'required|string|max:255|unique:payment_terms,name,' . $payment_term->id . ',id,setting_id,' . session('setting_id'),
+            'name'      => 'required|string|max:255|unique:payment_terms,name,' . $payment_term->id,
             'longevity' => 'required|integer|min:0', // allow 0
         ], [
             'longevity.min' => 'Tempo tidak boleh lebih kecil dari 0',

--- a/Modules/Setting/Http/Controllers/TaxController.php
+++ b/Modules/Setting/Http/Controllers/TaxController.php
@@ -53,14 +53,13 @@ class TaxController extends Controller
         ]);
 
         $request->validate([
-            'name'  => 'required|string|max:255|unique:taxes,name,NULL,id,setting_id,' . session('setting_id'),
+            'name'  => 'required|string|max:255|unique:taxes,name',
             'value' => 'required|numeric|gt:0|lte:100',
         ]);
 
         Tax::create([
             'name'       => $request->name,         // already uppercased
             'value'      => $request->value,
-            'setting_id' => session('setting_id'),
         ]);
 
         toast('Pajak Berhasil ditambahkan!', 'success');
@@ -95,7 +94,7 @@ class TaxController extends Controller
         ]);
 
         $request->validate([
-            'name'  => 'required|string|max:255|unique:taxes,name,' . $tax->id . ',id,setting_id,' . session('setting_id'),
+            'name'  => 'required|string|max:255|unique:taxes,name,' . $tax->id,
             'value' => 'required|numeric|gt:0|lte:100',
         ]);
 

--- a/app/Livewire/Pos/Checkout.php
+++ b/app/Livewire/Pos/Checkout.php
@@ -57,7 +57,7 @@ class Checkout extends Component
         $this->total_amount = 0;
 
         session('setting_id');
-        $this->paymentMethods = PaymentMethod::where('setting_id', session('setting_id'))->get();
+        $this->paymentMethods = PaymentMethod::all();
     }
 
     public function hydrate()

--- a/app/Livewire/Sale/CreateForm.php
+++ b/app/Livewire/Sale/CreateForm.php
@@ -37,7 +37,7 @@ class CreateForm extends Component
         $this->reference = 'SL'; // This can be dynamic if needed
         $this->date = now()->format('Y-m-d');
         $this->due_date = now()->format('Y-m-d');
-        $this->paymentTerms = PaymentTerm::where('setting_id', session('setting_id'))->get();
+        $this->paymentTerms = PaymentTerm::all();
     }
 
     public function updatedCustomerId($value)

--- a/app/Livewire/Sale/EditForm.php
+++ b/app/Livewire/Sale/EditForm.php
@@ -40,7 +40,7 @@ class EditForm extends Component
         $this->dueDate        = Carbon::parse($sale->due_date)->format('Y-m-d');
         $this->paymentTermId  = $sale->payment_term_id;
         $this->note           = $sale->note;
-        $this->paymentTerms   = PaymentTerm::where('setting_id', session('setting_id'))->get();
+        $this->paymentTerms   = PaymentTerm::all();
 
         // Rebuild the cart from the existing sale details
         Cart::instance('sale')->destroy();

--- a/app/Livewire/Sale/ProductCart.php
+++ b/app/Livewire/Sale/ProductCart.php
@@ -34,8 +34,7 @@ class ProductCart extends Component
     public $unit_price;
     public $data;
 
-    public $taxes; // Collection of taxes filtered by setting_id
-    public $setting_id; // Current setting ID
+    public $taxes;
     public $product_tax = []; // Array to store selected tax IDs for each product
 
     public $is_tax_included = true;
@@ -62,8 +61,7 @@ class ProductCart extends Component
     public function mount($cartInstance, $data = null): void
     {
         $this->cart_instance = $cartInstance;
-        $this->setting_id = session('setting_id');
-        $this->taxes = Tax::where('setting_id', $this->setting_id)->get();
+        $this->taxes = Tax::all();
 
         if ($data) {
             $this->data = $data;

--- a/database/migrations/2025_10_05_000001_remove_setting_id_from_shared_master_tables.php
+++ b/database/migrations/2025_10_05_000001_remove_setting_id_from_shared_master_tables.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('payment_terms', 'setting_id')) {
+            Schema::table('payment_terms', function (Blueprint $table) {
+                $table->dropForeign(['setting_id']);
+                $table->dropColumn('setting_id');
+            });
+        }
+
+        if (Schema::hasColumn('payment_methods', 'setting_id')) {
+            Schema::table('payment_methods', function (Blueprint $table) {
+                $table->dropColumn('setting_id');
+            });
+        }
+
+        if (Schema::hasColumn('taxes', 'setting_id')) {
+            Schema::table('taxes', function (Blueprint $table) {
+                $table->dropForeign(['setting_id']);
+                $table->dropColumn('setting_id');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasColumn('payment_terms', 'setting_id')) {
+            Schema::table('payment_terms', function (Blueprint $table) {
+                $table->unsignedBigInteger('setting_id')->after('id');
+                $table->foreign('setting_id')->references('id')->on('settings')->onDelete('cascade');
+            });
+        }
+
+        if (! Schema::hasColumn('payment_methods', 'setting_id')) {
+            Schema::table('payment_methods', function (Blueprint $table) {
+                $table->unsignedBigInteger('setting_id')->after('coa_id');
+            });
+        }
+
+        if (! Schema::hasColumn('taxes', 'setting_id')) {
+            Schema::table('taxes', function (Blueprint $table) {
+                $table->unsignedBigInteger('setting_id')->after('id');
+                $table->foreign('setting_id')->references('id')->on('settings')->onDelete('cascade');
+            });
+        }
+    }
+};

--- a/tests/Feature/SaleMonetaryValuesTest.php
+++ b/tests/Feature/SaleMonetaryValuesTest.php
@@ -77,7 +77,6 @@ class SaleMonetaryValuesTest extends TestCase
         ]);
 
         $this->paymentTerm = PaymentTerm::create([
-            'setting_id' => $this->setting->id,
             'name' => 'NET 10',
             'longevity' => 10,
         ]);
@@ -136,7 +135,6 @@ class SaleMonetaryValuesTest extends TestCase
         $this->paymentMethod = PaymentMethod::create([
             'name' => 'Cash',
             'coa_id' => $chartOfAccount->id,
-            'setting_id' => $this->setting->id,
         ]);
     }
 

--- a/tests/Feature/SaleSharedMasterDataTest.php
+++ b/tests/Feature/SaleSharedMasterDataTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\CheckUserRoleForSetting;
+use App\Livewire\Sale\CreateForm;
+use App\Livewire\Sale\ProductCart;
+use App\Models\User;
+use Gloudemans\Shoppingcart\Facades\Cart;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Session;
+use Livewire\Livewire;
+use Modules\People\Entities\Customer;
+use Modules\Purchase\Entities\PaymentTerm;
+use Modules\Sale\Entities\Sale;
+use Modules\Setting\Entities\ChartOfAccount;
+use Modules\Setting\Entities\Currency;
+use Modules\Setting\Entities\PaymentMethod;
+use Modules\Setting\Entities\Setting;
+use Modules\Setting\Entities\Tax;
+use Tests\TestCase;
+
+class SaleSharedMasterDataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected Setting $primarySetting;
+    protected Setting $secondarySetting;
+    protected PaymentTerm $sharedTerm;
+    protected PaymentMethod $sharedMethod;
+    protected Tax $sharedTax;
+    protected Customer $primaryCustomer;
+    protected Customer $secondaryCustomer;
+    protected Sale $sale;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Gate::before(fn () => true);
+        $this->withoutMiddleware(CheckUserRoleForSetting::class);
+
+        Cart::instance('sale')->destroy();
+
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $currency = Currency::create([
+            'currency_name' => 'Rupiah',
+            'code' => 'IDR',
+            'symbol' => 'Rp',
+            'thousand_separator' => '.',
+            'decimal_separator' => ',',
+            'exchange_rate' => 1,
+        ]);
+
+        $this->primarySetting = Setting::create([
+            'company_name' => 'Primary Co',
+            'company_email' => 'primary@example.com',
+            'company_phone' => '123456789',
+            'site_logo' => null,
+            'default_currency_id' => $currency->id,
+            'default_currency_position' => 'left',
+            'notification_email' => 'notify@example.com',
+            'footer_text' => 'Footer',
+            'company_address' => 'Address 1',
+        ]);
+
+        $this->secondarySetting = Setting::create([
+            'company_name' => 'Secondary Co',
+            'company_email' => 'secondary@example.com',
+            'company_phone' => '987654321',
+            'site_logo' => null,
+            'default_currency_id' => $currency->id,
+            'default_currency_position' => 'left',
+            'notification_email' => 'notify2@example.com',
+            'footer_text' => 'Footer 2',
+            'company_address' => 'Address 2',
+        ]);
+
+        Session::put('setting_id', $this->primarySetting->id);
+
+        $chartOfAccount = ChartOfAccount::create([
+            'name' => 'Kas',
+            'account_number' => '1000',
+            'category' => 'Kas & Bank',
+            'parent_account_id' => null,
+            'tax_id' => null,
+            'description' => null,
+            'setting_id' => $this->primarySetting->id,
+        ]);
+
+        $this->sharedMethod = PaymentMethod::create([
+            'name' => 'Shared Cash',
+            'coa_id' => $chartOfAccount->id,
+        ]);
+
+        $this->sharedTerm = PaymentTerm::create([
+            'name' => 'Global Term',
+            'longevity' => 7,
+        ]);
+
+        $this->sharedTax = Tax::create([
+            'name' => 'VAT 10',
+            'value' => 10,
+        ]);
+
+        $this->primaryCustomer = Customer::factory()->create([
+            'setting_id' => $this->primarySetting->id,
+            'payment_term_id' => $this->sharedTerm->id,
+        ]);
+
+        $this->secondaryCustomer = Customer::factory()->create([
+            'setting_id' => $this->secondarySetting->id,
+            'payment_term_id' => $this->sharedTerm->id,
+        ]);
+
+        $this->sale = Sale::create([
+            'date' => now()->toDateString(),
+            'due_date' => now()->addDays(7)->toDateString(),
+            'customer_id' => $this->primaryCustomer->id,
+            'customer_name' => $this->primaryCustomer->customer_name,
+            'tax_percentage' => 0,
+            'tax_amount' => 0,
+            'discount_percentage' => 0,
+            'discount_amount' => 0,
+            'shipping_amount' => 0,
+            'total_amount' => 100,
+            'paid_amount' => 0,
+            'due_amount' => 100,
+            'status' => Sale::STATUS_DRAFTED,
+            'payment_status' => 'unpaid',
+            'payment_method' => '',
+            'note' => null,
+            'payment_term_id' => $this->sharedTerm->id,
+            'tax_id' => null,
+            'setting_id' => $this->primarySetting->id,
+            'is_tax_included' => false,
+        ]);
+    }
+
+    public function test_sale_create_view_lists_shared_master_data(): void
+    {
+        $response = $this->get(route('sales.create'));
+
+        $response->assertOk();
+        $response->assertViewHas('paymentTerms', fn ($terms) => $terms->contains('id', $this->sharedTerm->id));
+        $response->assertViewHas('customers', fn ($customers) => $customers->contains('id', $this->secondaryCustomer->id));
+    }
+
+    public function test_sale_payments_use_shared_payment_methods(): void
+    {
+        $response = $this->get(route('sale-payments.create', $this->sale->id));
+
+        $response->assertOk();
+        $response->assertViewHas('payment_methods', fn ($methods) => $methods->contains('id', $this->sharedMethod->id));
+    }
+
+    public function test_livewire_components_pull_shared_master_data(): void
+    {
+        Livewire::test(CreateForm::class)
+            ->assertSet('paymentTerms', fn ($terms) => $terms->contains('id', $this->sharedTerm->id));
+
+        Livewire::test(ProductCart::class, ['cartInstance' => 'sale'])
+            ->assertSet('taxes', fn ($taxes) => $taxes->contains('id', $this->sharedTax->id));
+    }
+}


### PR DESCRIPTION
## Summary
- remove per-setting columns from payment terms, payment methods, and taxes and provide a migration to drop them on existing installs
- update sales, purchase, and POS flows to load shared master data and enforce stricter payment method validation
- add feature coverage ensuring sales components can access cross-setting customers, payment terms, payment methods, and taxes

## Testing
- not run (composer install fails on PHP 8.4 due to upstream package constraints)


------
https://chatgpt.com/codex/tasks/task_e_68e1119d172c83268625f8f397461728