### PR TITLE
Aggregate sale cart items before persisting details

### DIFF
--- a/Modules/Sale/Services/SaleCartAggregator.php
+++ b/Modules/Sale/Services/SaleCartAggregator.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Modules\Sale\Services;
+
+use Illuminate\Support\Collection;
+
+class SaleCartAggregator
+{
+    /**
+     * Aggregate cart rows by product and tax combination.
+     *
+     * @param  \Illuminate\Support\Collection|array  $cartItems
+     * @return array<int, array<string, mixed>>
+     */
+    public static function aggregate($cartItems): array
+    {
+        if ($cartItems instanceof Collection) {
+            $cartItems = $cartItems->all();
+        }
+
+        $aggregated = [];
+
+        foreach ($cartItems as $item) {
+            $options = is_array($item->options) ? $item->options : $item->options->toArray();
+
+            $productId = $options['product_id'] ?? $item->id;
+            $taxId = $options['product_tax'] ?? null;
+            $key = $productId . ':' . ($taxId ?? 'null');
+
+            if (! isset($aggregated[$key])) {
+                $aggregated[$key] = [
+                    'product_id' => $productId,
+                    'product_name' => $item->name,
+                    'product_code' => $options['code'] ?? null,
+                    'product_discount_type' => $options['product_discount_type'] ?? null,
+                    'tax_id' => $taxId,
+                    'quantity' => 0,
+                    'unit_price_total' => 0.0,
+                    'price_total' => 0.0,
+                    'product_discount_amount' => 0.0,
+                    'sub_total' => 0.0,
+                    'sub_total_before_tax' => 0.0,
+                    'product_tax_amount' => 0.0,
+                    'bundle_items' => [],
+                ];
+            }
+
+            $qty = (float) $item->qty;
+            $subTotal = (float) ($options['sub_total'] ?? ($item->price * $qty));
+            $subTotalBeforeTax = (float) ($options['sub_total_before_tax'] ?? $subTotal);
+            $unitPrice = (float) ($options['unit_price'] ?? $item->price);
+            $price = (float) $item->price;
+            $discountAmount = (float) ($options['product_discount'] ?? 0);
+
+            $aggregated[$key]['quantity'] += $qty;
+            $aggregated[$key]['unit_price_total'] += $unitPrice * $qty;
+            $aggregated[$key]['price_total'] += $price * $qty;
+            $aggregated[$key]['product_discount_amount'] += $discountAmount;
+            $aggregated[$key]['sub_total'] += $subTotal;
+            $aggregated[$key]['sub_total_before_tax'] += $subTotalBeforeTax;
+            $aggregated[$key]['product_tax_amount'] += $subTotal - $subTotalBeforeTax;
+
+            $bundleItems = $options['bundle_items'] ?? [];
+            if (is_iterable($bundleItems)) {
+                foreach ($bundleItems as $bundleItem) {
+                    $bundleItem = is_array($bundleItem) ? $bundleItem : (array) $bundleItem;
+                    $bundleKey = ($bundleItem['bundle_item_id'] ?? 'null') . ':' . ($bundleItem['product_id'] ?? 'null');
+
+                    if (! isset($aggregated[$key]['bundle_items'][$bundleKey])) {
+                        $aggregated[$key]['bundle_items'][$bundleKey] = [
+                            'bundle_id' => $bundleItem['bundle_id'] ?? null,
+                            'bundle_item_id' => $bundleItem['bundle_item_id'] ?? null,
+                            'product_id' => $bundleItem['product_id'] ?? null,
+                            'name' => $bundleItem['name'] ?? null,
+                            'tax_id' => $bundleItem['tax_id'] ?? null,
+                            'quantity' => 0.0,
+                            'sub_total' => 0.0,
+                            'price_total' => 0.0,
+                        ];
+                    }
+
+                    $bundleQty = (float) ($bundleItem['quantity'] ?? 0);
+                    $bundleSubTotal = array_key_exists('sub_total', $bundleItem)
+                        ? (float) $bundleItem['sub_total']
+                        : null;
+                    $bundlePrice = (float) ($bundleItem['price'] ?? 0);
+
+                    $aggregated[$key]['bundle_items'][$bundleKey]['quantity'] += $bundleQty;
+                    $aggregated[$key]['bundle_items'][$bundleKey]['sub_total'] += $bundleSubTotal ?? ($bundlePrice * $bundleQty);
+                    $aggregated[$key]['bundle_items'][$bundleKey]['price_total'] += $bundlePrice * $bundleQty;
+                }
+            }
+        }
+
+        foreach ($aggregated as &$entry) {
+            $entry['unit_price'] = $entry['quantity'] > 0 ? $entry['unit_price_total'] / $entry['quantity'] : 0;
+            $entry['price'] = $entry['quantity'] > 0 ? $entry['price_total'] / $entry['quantity'] : 0;
+
+            $entry['bundle_items'] = array_map(function ($bundle) {
+                $quantity = $bundle['quantity'];
+                $price = $quantity > 0 ? $bundle['price_total'] / $quantity : 0;
+
+                return [
+                    'bundle_id' => $bundle['bundle_id'],
+                    'bundle_item_id' => $bundle['bundle_item_id'],
+                    'product_id' => $bundle['product_id'],
+                    'name' => $bundle['name'],
+                    'tax_id' => $bundle['tax_id'] ?? null,
+                    'price' => $price,
+                    'quantity' => $quantity,
+                    'sub_total' => $bundle['sub_total'],
+                ];
+            }, $entry['bundle_items']);
+
+            unset($entry['unit_price_total'], $entry['price_total']);
+        }
+
+        return array_values($aggregated);
+    }
+}
+

--- a/app/Livewire/Sale/CreateForm.php
+++ b/app/Livewire/Sale/CreateForm.php
@@ -13,6 +13,7 @@ use Modules\Purchase\Entities\PaymentTerm;
 use Modules\Sale\Entities\Sale;
 use Modules\Sale\Entities\SaleBundleItem;
 use Modules\Sale\Entities\SaleDetails;
+use Modules\Sale\Services\SaleCartAggregator;
 
 class CreateForm extends Component
 {
@@ -109,6 +110,7 @@ class CreateForm extends Component
         try {
             $settingId = session('setting_id');
             $cartItems = Cart::instance('sale')->content();
+            $aggregatedItems = SaleCartAggregator::aggregate($cartItems);
 
             // Totals
             $totalSub       = $cartItems->sum(fn($i) => $i->options['sub_total']);
@@ -142,24 +144,23 @@ class CreateForm extends Component
             ]);
 
             // Details & Bundles
-            foreach ($cartItems as $item) {
-                $lineTax = $item->options['sub_total'] - ($item->options['sub_total_before_tax'] ?? 0);
+            foreach ($aggregatedItems as $item) {
                 $detail = SaleDetails::create([
                     'sale_id'                 => $sale->id,
-                    'product_id'              => $item->options['product_id'],
-                    'product_name'            => $item->name,
-                    'product_code'            => $item->options['code'],
-                    'quantity'                => $item->qty,
-                    'unit_price'              => $item->options['unit_price'],
-                    'price'                   => $item->price,
-                    'product_discount_type'   => $item->options['product_discount_type'],
-                    'product_discount_amount' => $item->options['product_discount'],
-                    'sub_total'               => $item->options['sub_total'],
-                    'product_tax_amount'      => $lineTax,
-                    'tax_id'                  => $item->options['product_tax'],
+                    'product_id'              => $item['product_id'],
+                    'product_name'            => $item['product_name'],
+                    'product_code'            => $item['product_code'],
+                    'quantity'                => $item['quantity'],
+                    'unit_price'              => round((float) $item['unit_price'], 2),
+                    'price'                   => round((float) $item['price'], 2),
+                    'product_discount_type'   => $item['product_discount_type'],
+                    'product_discount_amount' => round((float) $item['product_discount_amount'], 2),
+                    'sub_total'               => round((float) $item['sub_total'], 2),
+                    'product_tax_amount'      => round((float) $item['product_tax_amount'], 2),
+                    'tax_id'                  => $item['tax_id'],
                 ]);
 
-                foreach ($item->options['bundle_items'] ?? [] as $b) {
+                foreach ($item['bundle_items'] ?? [] as $b) {
                     SaleBundleItem::create([
                         'sale_detail_id' => $detail->id,
                         'sale_id'        => $sale->id,
@@ -167,9 +168,9 @@ class CreateForm extends Component
                         'bundle_item_id' => $b['bundle_item_id'] ?? null,
                         'product_id'     => $b['product_id'],
                         'name'           => $b['name'],
-                        'price'          => $b['price'],
+                        'price'          => round((float) ($b['price'] ?? 0), 2),
                         'quantity'       => $b['quantity'],
-                        'sub_total'      => $b['sub_total'],
+                        'sub_total'      => round((float) ($b['sub_total'] ?? 0), 2),
                     ]);
                 }
             }


### PR DESCRIPTION
## Summary
- add a reusable sale cart aggregator to group cart rows by product/tax and sum monetary fields
- update the sale controller and Livewire create form to persist aggregated sale details and bundle items
- cover duplicate cart rows with a feature test that verifies a single sale detail is stored with combined totals

## Testing
- php artisan test --filter=SaleMonetaryValuesTest *(fails: composer install requires a GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1165eac388326818858f43279d2d5