### PR TITLE
Add migration to update sale bundle item monetary columns

### DIFF
--- a/Modules/Sale/Database/Migrations/2025_10_05_000001_update_price_columns_on_sale_bundle_items_table.php
+++ b/Modules/Sale/Database/Migrations/2025_10_05_000001_update_price_columns_on_sale_bundle_items_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('sale_bundle_items', function (Blueprint $table) {
+            $table->decimal('price', 15, 2)->change();
+            $table->decimal('sub_total', 15, 2)->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('sale_bundle_items', function (Blueprint $table) {
+            $table->integer('price')->change();
+            $table->integer('sub_total')->change();
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- restore the original sale bundle item table definition that already ran in production
- add a dedicated follow-up migration to convert sale bundle item price and subtotal columns to decimal for monetary precision

## Testing
- composer install --no-interaction --prefer-dist *(fails: PHP 8.4 not supported by locked dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e1445a3aac832691d356ea69675b22