### PR TITLE
Use per-setting product prices in views

### DIFF
--- a/Modules/Product/Http/Controllers/ProductController.php
+++ b/Modules/Product/Http/Controllers/ProductController.php
@@ -238,15 +238,15 @@ class ProductController extends Controller
             ->where('setting_id', $settingId)
             ->first();
 
-        // Prefer product_prices; fallback to legacy columns on products
+        // Prefer product_prices exclusively (default to zero/blank when row missing)
         $price = (object) [
-            'sale_price'             => data_get($pp, 'sale_price',             $product->sale_price),
-            'tier_1_price'           => data_get($pp, 'tier_1_price',           $product->tier_1_price),
-            'tier_2_price'           => data_get($pp, 'tier_2_price',           $product->tier_2_price),
-            'last_purchase_price'    => data_get($pp, 'last_purchase_price',    $product->last_purchase_price ?? $product->purchase_price),
-            'average_purchase_price' => data_get($pp, 'average_purchase_price', $product->average_purchase_price ?? $product->purchase_price),
-            'purchase_tax_id'        => data_get($pp, 'purchase_tax_id',        $product->purchase_tax_id),
-            'sale_tax_id'            => data_get($pp, 'sale_tax_id',            $product->sale_tax_id),
+            'sale_price'             => data_get($pp, 'sale_price', 0),
+            'tier_1_price'           => data_get($pp, 'tier_1_price', 0),
+            'tier_2_price'           => data_get($pp, 'tier_2_price', 0),
+            'last_purchase_price'    => data_get($pp, 'last_purchase_price', 0),
+            'average_purchase_price' => data_get($pp, 'average_purchase_price', 0),
+            'purchase_tax_id'        => data_get($pp, 'purchase_tax_id'),
+            'sale_tax_id'            => data_get($pp, 'sale_tax_id'),
         ];
 
         // --- quantity display (unchanged) ---
@@ -338,15 +338,15 @@ class ProductController extends Controller
             ->where('setting_id', $settingId)
             ->first();
 
-        // Always prefer the per-setting price row. If it is missing, fall back to zeros (no legacy columns).
+        // Always prefer the per-setting price row. If it is missing, default to zero/blank values.
         $price = (object) [
-            // For editing “Harga Beli” we’ll show last_purchase_price (or fallback)
-            'purchase_price'  => data_get($pp, 'last_purchase_price', $product->purchase_price),
-            'sale_price'      => data_get($pp, 'sale_price',      $product->sale_price),
-            'tier_1_price'    => data_get($pp, 'tier_1_price',    $product->tier_1_price),
-            'tier_2_price'    => data_get($pp, 'tier_2_price',    $product->tier_2_price),
-            'purchase_tax_id' => data_get($pp, 'purchase_tax_id', $product->purchase_tax_id),
-            'sale_tax_id'     => data_get($pp, 'sale_tax_id',     $product->sale_tax_id),
+            // For editing “Harga Beli” we’ll show last_purchase_price only
+            'purchase_price'  => data_get($pp, 'last_purchase_price', 0),
+            'sale_price'      => data_get($pp, 'sale_price', 0),
+            'tier_1_price'    => data_get($pp, 'tier_1_price', 0),
+            'tier_2_price'    => data_get($pp, 'tier_2_price', 0),
+            'purchase_tax_id' => data_get($pp, 'purchase_tax_id'),
+            'sale_tax_id'     => data_get($pp, 'sale_tax_id'),
         ];
 
         // existing media for the dropzone

--- a/Modules/Product/Resources/views/products/show.blade.php
+++ b/Modules/Product/Resources/views/products/show.blade.php
@@ -20,15 +20,13 @@
                     <div class="card-body">
                         <div class="table-responsive">
                             @php
-                                // Prefer per-setting prices from $price; fall back to legacy fields on $product
-                                $salePrice   = $price->sale_price ?? $product->sale_price;
-                                $tier1Price  = $price->tier_1_price ?? $product->tier_1_price;
-                                $tier2Price  = $price->tier_2_price ?? $product->tier_2_price;
+                                // Prefer per-setting prices from $price; default to zeros when price row is missing
+                                $salePrice   = $price->sale_price ?? 0;
+                                $tier1Price  = $price->tier_1_price ?? 0;
+                                $tier2Price  = $price->tier_2_price ?? 0;
 
-                                $lastBuy     = $price->last_purchase_price
-                                                ?? ($product->last_purchase_price ?? $product->purchase_price);
-                                $avgBuy      = $price->average_purchase_price
-                                                ?? ($product->average_purchase_price ?? $product->purchase_price);
+                                $lastBuy     = $price->last_purchase_price ?? 0;
+                                $avgBuy      = $price->average_purchase_price ?? 0;
 
                                 // Taxes now come from product_prices (IDs); quick lookup for names (single page -> 2 queries OK)
                                 $purchaseTaxName = $price->purchase_tax_id

--- a/tests/Feature/ProductPriceViewTest.php
+++ b/tests/Feature/ProductPriceViewTest.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\CheckUserRoleForSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Modules\Currency\Entities\Currency;
+use Modules\Product\Entities\Product;
+use Modules\Product\Entities\ProductPrice;
+use Modules\Setting\Entities\Setting;
+use Tests\TestCase;
+
+class ProductPriceViewTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Currency $currency;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->currency = Currency::create([
+            'currency_name'       => 'Rupiah',
+            'code'                => 'IDR',
+            'symbol'              => 'Rp',
+            'thousand_separator'  => '.',
+            'decimal_separator'   => ',',
+            'exchange_rate'       => 1,
+        ]);
+    }
+
+    public function test_show_uses_per_setting_price_row_when_available(): void
+    {
+        Gate::shouldReceive('denies')->andReturnFalse();
+
+        $setting = $this->createSetting('Active Co');
+        $user    = User::factory()->create();
+
+        $product = Product::create([
+            'setting_id'              => $setting->id,
+            'product_name'            => 'Test Product',
+            'product_code'            => 'CODE-1',
+            'product_quantity'        => 5,
+            'product_cost'            => 0,
+            'product_price'           => 0,
+            'product_stock_alert'     => 0,
+            'is_purchased'            => false,
+            'is_sold'                 => false,
+            'sale_price'              => 9999, // Should be ignored
+            'tier_1_price'            => 8888, // Should be ignored
+            'tier_2_price'            => 7777, // Should be ignored
+            'last_purchase_price'     => 6666, // Should be ignored
+            'average_purchase_price'  => 5555, // Should be ignored
+        ]);
+
+        $priceRow = ProductPrice::create([
+            'product_id'             => $product->id,
+            'setting_id'             => $setting->id,
+            'sale_price'             => 1234,
+            'tier_1_price'           => 2234,
+            'tier_2_price'           => 3234,
+            'last_purchase_price'    => 4234,
+            'average_purchase_price' => 5234,
+        ]);
+
+        $this->actingAs($user);
+        $this->withoutMiddleware([CheckUserRoleForSetting::class]);
+
+        $response = $this->withSession(['setting_id' => $setting->id])
+            ->get(route('products.show', $product));
+
+        $response->assertOk();
+        $response->assertViewIs('product::products.show');
+        $response->assertViewHas('price', function ($price) use ($priceRow) {
+            $this->assertSame($priceRow->sale_price, $price->sale_price);
+            $this->assertSame($priceRow->tier_1_price, $price->tier_1_price);
+            $this->assertSame($priceRow->tier_2_price, $price->tier_2_price);
+            $this->assertSame($priceRow->last_purchase_price, $price->last_purchase_price);
+            $this->assertSame($priceRow->average_purchase_price, $price->average_purchase_price);
+
+            return true;
+        });
+    }
+
+    public function test_show_defaults_to_zero_when_price_row_missing(): void
+    {
+        Gate::shouldReceive('denies')->andReturnFalse();
+
+        $setting = $this->createSetting('Defaultless Co');
+        $user    = User::factory()->create();
+
+        $product = Product::create([
+            'setting_id'             => $setting->id,
+            'product_name'           => 'No Price Product',
+            'product_code'           => 'CODE-2',
+            'product_quantity'       => 5,
+            'product_cost'           => 0,
+            'product_price'          => 0,
+            'product_stock_alert'    => 0,
+            'sale_price'             => 9999, // Should not leak through
+            'tier_1_price'           => 8888,
+            'tier_2_price'           => 7777,
+            'last_purchase_price'    => 6666,
+            'average_purchase_price' => 5555,
+        ]);
+
+        $this->actingAs($user);
+        $this->withoutMiddleware([CheckUserRoleForSetting::class]);
+
+        $response = $this->withSession(['setting_id' => $setting->id])
+            ->get(route('products.show', $product));
+
+        $response->assertOk();
+        $response->assertViewHas('price', function ($price) {
+            $this->assertSame(0, $price->sale_price);
+            $this->assertSame(0, $price->tier_1_price);
+            $this->assertSame(0, $price->tier_2_price);
+            $this->assertSame(0, $price->last_purchase_price);
+            $this->assertSame(0, $price->average_purchase_price);
+            $this->assertNull($price->purchase_tax_id);
+            $this->assertNull($price->sale_tax_id);
+
+            return true;
+        });
+    }
+
+    public function test_edit_uses_per_setting_price_row_when_available(): void
+    {
+        Gate::shouldReceive('denies')->andReturnFalse();
+
+        $setting = $this->createSetting('Editable Co');
+        $user    = User::factory()->create();
+
+        $product = Product::create([
+            'setting_id'          => $setting->id,
+            'product_name'        => 'Editable Product',
+            'product_code'        => 'CODE-3',
+            'product_quantity'    => 5,
+            'product_cost'        => 0,
+            'product_price'       => 0,
+            'product_stock_alert' => 0,
+        ]);
+
+        $priceRow = ProductPrice::create([
+            'product_id'          => $product->id,
+            'setting_id'          => $setting->id,
+            'sale_price'          => 4321,
+            'tier_1_price'        => 3321,
+            'tier_2_price'        => 2321,
+            'last_purchase_price' => 1321,
+        ]);
+
+        $this->actingAs($user);
+        $this->withoutMiddleware([CheckUserRoleForSetting::class]);
+
+        $response = $this->withSession(['setting_id' => $setting->id])
+            ->get(route('products.edit', $product));
+
+        $response->assertOk();
+        $response->assertViewIs('product::products.edit');
+        $response->assertViewHas('price', function ($price) use ($priceRow) {
+            $this->assertSame($priceRow->last_purchase_price, $price->purchase_price);
+            $this->assertSame($priceRow->sale_price, $price->sale_price);
+            $this->assertSame($priceRow->tier_1_price, $price->tier_1_price);
+            $this->assertSame($priceRow->tier_2_price, $price->tier_2_price);
+
+            return true;
+        });
+    }
+
+    public function test_edit_defaults_to_zero_when_price_row_missing(): void
+    {
+        Gate::shouldReceive('denies')->andReturnFalse();
+
+        $setting = $this->createSetting('Zero Co');
+        $user    = User::factory()->create();
+
+        $product = Product::create([
+            'setting_id'          => $setting->id,
+            'product_name'        => 'Zero Product',
+            'product_code'        => 'CODE-4',
+            'product_quantity'    => 5,
+            'product_cost'        => 0,
+            'product_price'       => 0,
+            'product_stock_alert' => 0,
+        ]);
+
+        $this->actingAs($user);
+        $this->withoutMiddleware([CheckUserRoleForSetting::class]);
+
+        $response = $this->withSession(['setting_id' => $setting->id])
+            ->get(route('products.edit', $product));
+
+        $response->assertOk();
+        $response->assertViewHas('price', function ($price) {
+            $this->assertSame(0, $price->purchase_price);
+            $this->assertSame(0, $price->sale_price);
+            $this->assertSame(0, $price->tier_1_price);
+            $this->assertSame(0, $price->tier_2_price);
+            $this->assertNull($price->purchase_tax_id);
+            $this->assertNull($price->sale_tax_id);
+
+            return true;
+        });
+    }
+
+    private function createSetting(string $name): Setting
+    {
+        return Setting::create([
+            'company_name'              => $name,
+            'company_email'             => strtolower(str_replace(' ', '', $name)) . '@example.com',
+            'company_phone'             => '123456789',
+            'site_logo'                 => null,
+            'default_currency_id'       => $this->currency->id,
+            'default_currency_position' => 'left',
+            'notification_email'        => 'notify@example.com',
+            'footer_text'               => 'Footer',
+            'company_address'           => 'Address',
+        ]);
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure the product show and edit actions surface prices strictly from the per-setting ProductPrice row with zero/null defaults
- update the show blade to display price data sourced from the per-setting row only
- add feature coverage verifying show/edit controllers return the per-setting price data and zero defaults when rows are missing

## Testing
- `vendor/bin/phpunit --filter ProductPriceViewTest` *(fails: vendor directory unavailable because composer install cannot run on PHP 8.4 due to package constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68e15036f55883268dee2af973adb172