### PR TITLE
Adjust product price flag backfill to use product_prices table

### DIFF
--- a/Modules/Product/Database/Migrations/2025_09_05_120000_backfill_product_price_flags.php
+++ b/Modules/Product/Database/Migrations/2025_09_05_120000_backfill_product_price_flags.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\\Database\\Migrations\\Migration;
+use Illuminate\\Support\\Facades\\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('products')
+            ->whereIn('id', function ($subQuery) {
+                $subQuery->select('product_id')
+                    ->from('product_prices')
+                    ->where(function ($priceQuery) {
+                        $priceQuery->where('last_purchase_price', '>', 0)
+                            ->orWhere('average_purchase_price', '>', 0);
+                    });
+            })
+            ->update(['is_purchased' => true]);
+
+        DB::table('products')
+            ->whereIn('id', function ($subQuery) {
+                $subQuery->select('product_id')
+                    ->from('product_prices')
+                    ->where(function ($priceQuery) {
+                        $priceQuery->where('sale_price', '>', 0)
+                            ->orWhere('tier_1_price', '>', 0)
+                            ->orWhere('tier_2_price', '>', 0);
+                    });
+            })
+            ->update(['is_sold' => true]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Intentionally left blank - backfilled data should not be reverted automatically.
+    }
+};


### PR DESCRIPTION
## Summary
- add a data backfill migration to ensure product purchase/sale flags are enabled when any prices exist
- rely on product_prices table data without loading models to determine which products should be flagged

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e173fcd51c8326bf567eccd362dfb4