### PR TITLE
Add approval and receiving workflow to sales returns

### DIFF
--- a/Modules/SalesReturn/Database/Migrations/2025_11_05_000001_add_receiving_columns_to_sale_returns_table.php
+++ b/Modules/SalesReturn/Database/Migrations/2025_11_05_000001_add_receiving_columns_to_sale_returns_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('sale_returns', function (Blueprint $table) {
+            if (! Schema::hasColumn('sale_returns', 'received_by')) {
+                $table->foreignId('received_by')
+                    ->nullable()
+                    ->after('settled_by')
+                    ->constrained('users')
+                    ->nullOnDelete();
+            }
+
+            if (! Schema::hasColumn('sale_returns', 'received_at')) {
+                $table->timestamp('received_at')
+                    ->nullable()
+                    ->after('received_by');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('sale_returns', function (Blueprint $table) {
+            if (Schema::hasColumn('sale_returns', 'received_at')) {
+                $table->dropColumn('received_at');
+            }
+
+            if (Schema::hasColumn('sale_returns', 'received_by')) {
+                $table->dropConstrainedForeignId('received_by');
+            }
+        });
+    }
+};

--- a/Modules/SalesReturn/Entities/SaleReturn.php
+++ b/Modules/SalesReturn/Entities/SaleReturn.php
@@ -27,6 +27,7 @@ class SaleReturn extends BaseModel
         'approved_at'      => 'datetime',
         'rejected_at'      => 'datetime',
         'settled_at'       => 'datetime',
+        'received_at'      => 'datetime',
     ];
 
     public function saleReturnDetails(): Builder|HasMany|SaleReturn
@@ -77,6 +78,11 @@ class SaleReturn extends BaseModel
     public function settledBy(): BelongsTo
     {
         return $this->belongsTo(User::class, 'settled_by');
+    }
+
+    public function receivedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'received_by');
     }
 
     public static function boot(): void

--- a/Modules/SalesReturn/Http/Controllers/SalesReturnController.php
+++ b/Modules/SalesReturn/Http/Controllers/SalesReturnController.php
@@ -2,10 +2,21 @@
 
 namespace Modules\SalesReturn\Http\Controllers;
 
-use Modules\SalesReturn\DataTables\SaleReturnsDataTable;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Modules\Product\Entities\Product;
+use Modules\Product\Entities\ProductSerialNumber;
+use Modules\Product\Entities\ProductStock;
+use Modules\Sale\Entities\DispatchDetail;
+use Modules\Sale\Entities\Sale;
+use Modules\SalesReturn\DataTables\SaleReturnsDataTable;
 use Modules\SalesReturn\Entities\SaleReturn;
+use Modules\SalesReturn\Entities\SaleReturnDetail;
+use Throwable;
 
 class SalesReturnController extends Controller
 {
@@ -56,5 +67,257 @@ class SalesReturnController extends Controller
         toast('Retur Penjualan Dihapus!', 'warning');
 
         return redirect()->route('sale-returns.index');
+    }
+
+    public function approve(SaleReturn $sale_return)
+    {
+        abort_if(Gate::denies('saleReturns.approve'), 403);
+
+        $status = Str::lower($sale_return->approval_status ?? '');
+
+        if ($status === 'approved') {
+            toast('Retur penjualan sudah disetujui.', 'info');
+            return back();
+        }
+
+        if ($status === 'rejected') {
+            toast('Retur penjualan yang ditolak tidak dapat disetujui.', 'error');
+            return back();
+        }
+
+        $sale_return->update([
+            'approval_status' => 'approved',
+            'status' => 'Awaiting Receiving',
+            'approved_by' => auth()->id(),
+            'approved_at' => now(),
+            'rejected_by' => null,
+            'rejected_at' => null,
+            'rejection_reason' => null,
+            'received_by' => null,
+            'received_at' => null,
+            'settled_at' => null,
+            'settled_by' => null,
+        ]);
+
+        toast('Retur penjualan disetujui.', 'success');
+
+        return back();
+    }
+
+    public function reject(Request $request, SaleReturn $sale_return)
+    {
+        abort_if(Gate::denies('saleReturns.approve'), 403);
+
+        $status = Str::lower($sale_return->approval_status ?? '');
+
+        if ($status === 'approved') {
+            toast('Retur penjualan yang sudah disetujui tidak dapat ditolak.', 'error');
+            return back();
+        }
+
+        $data = $request->validate([
+            'reason' => ['nullable', 'string', 'max:1000'],
+        ]);
+
+        $sale_return->update([
+            'approval_status' => 'rejected',
+            'status' => 'Rejected',
+            'rejected_by' => auth()->id(),
+            'rejected_at' => now(),
+            'rejection_reason' => $data['reason'] ?? null,
+            'approved_by' => null,
+            'approved_at' => null,
+            'received_by' => null,
+            'received_at' => null,
+            'settled_at' => null,
+            'settled_by' => null,
+        ]);
+
+        toast('Retur penjualan ditolak.', 'warning');
+
+        return back();
+    }
+
+    public function receive(SaleReturn $sale_return)
+    {
+        abort_if(Gate::denies('saleReturns.receive'), 403);
+
+        $approvalStatus = Str::lower($sale_return->approval_status ?? '');
+        $status = Str::lower($sale_return->status ?? '');
+
+        if ($approvalStatus !== 'approved') {
+            toast('Retur penjualan harus disetujui sebelum diterima.', 'error');
+            return back();
+        }
+
+        if ($status === 'awaiting settlement' || $status === 'completed') {
+            toast('Retur penjualan sudah diterima.', 'info');
+            return back();
+        }
+
+        if ($status !== 'awaiting receiving') {
+            toast('Retur penjualan belum siap untuk diterima.', 'error');
+            return back();
+        }
+
+        try {
+            DB::transaction(function () use ($sale_return) {
+                $lockedSaleReturn = SaleReturn::query()
+                    ->whereKey($sale_return->id)
+                    ->lockForUpdate()
+                    ->firstOrFail();
+
+                $details = SaleReturnDetail::query()
+                    ->with('dispatchDetail')
+                    ->where('sale_return_id', $lockedSaleReturn->id)
+                    ->lockForUpdate()
+                    ->get();
+
+                $dispatchDetails = DispatchDetail::query()
+                    ->whereIn('id', $details->pluck('dispatch_detail_id')->filter()->unique()->all())
+                    ->lockForUpdate()
+                    ->get()
+                    ->keyBy('id');
+
+                foreach ($details as $detail) {
+                    $quantity = (int) ($detail->quantity ?? 0);
+                    if ($quantity <= 0) {
+                        continue;
+                    }
+
+                    $dispatchDetail = $dispatchDetails->get($detail->dispatch_detail_id);
+                    if (! $dispatchDetail) {
+                        throw new \RuntimeException('Detail pengiriman tidak ditemukan untuk retur penjualan.');
+                    }
+
+                    $locationId = $detail->location_id
+                        ?? $lockedSaleReturn->location_id
+                        ?? $dispatchDetail->location_id;
+
+                    if (! $locationId) {
+                        throw new \RuntimeException('Lokasi penerimaan retur tidak dapat ditentukan.');
+                    }
+
+                    $product = Product::query()
+                        ->where('id', $detail->product_id)
+                        ->lockForUpdate()
+                        ->firstOrFail();
+
+                    $productStock = ProductStock::query()
+                        ->where('product_id', $detail->product_id)
+                        ->where('location_id', $locationId)
+                        ->lockForUpdate()
+                        ->first();
+
+                    if (! $productStock) {
+                        $productStock = ProductStock::create([
+                            'product_id' => $detail->product_id,
+                            'location_id' => $locationId,
+                            'quantity' => 0,
+                            'quantity_tax' => 0,
+                            'quantity_non_tax' => 0,
+                            'broken_quantity_non_tax' => 0,
+                            'broken_quantity_tax' => 0,
+                            'broken_quantity' => 0,
+                            'tax_id' => $dispatchDetail->tax_id,
+                        ]);
+                    }
+
+                    $taxId = $dispatchDetail->tax_id;
+
+                    if ($taxId) {
+                        $productStock->quantity_tax = (int) ($productStock->quantity_tax ?? 0) + $quantity;
+                    } else {
+                        $productStock->quantity_non_tax = (int) ($productStock->quantity_non_tax ?? 0) + $quantity;
+                    }
+
+                    $productStock->quantity = (int) ($productStock->quantity_non_tax ?? 0)
+                        + (int) ($productStock->quantity_tax ?? 0)
+                        + (int) ($productStock->broken_quantity_non_tax ?? 0)
+                        + (int) ($productStock->broken_quantity_tax ?? 0);
+                    $productStock->broken_quantity = (int) ($productStock->broken_quantity_non_tax ?? 0)
+                        + (int) ($productStock->broken_quantity_tax ?? 0);
+                    $productStock->tax_id = $taxId;
+                    $productStock->save();
+
+                    $product->product_quantity = (int) $product->product_quantity + $quantity;
+                    $product->save();
+
+                    $serialIds = collect($detail->serial_number_ids ?? [])
+                        ->map(fn ($id) => (int) $id)
+                        ->filter()
+                        ->values()
+                        ->all();
+
+                    if (! empty($serialIds)) {
+                        $serials = ProductSerialNumber::query()
+                            ->whereIn('id', $serialIds)
+                            ->lockForUpdate()
+                            ->get();
+
+                        if ($serials->count() !== count($serialIds)) {
+                            throw new \RuntimeException('Sebagian nomor seri tidak ditemukan.');
+                        }
+
+                        foreach ($serials as $serial) {
+                            if ((int) $serial->dispatch_detail_id !== (int) $dispatchDetail->id) {
+                                throw new \RuntimeException('Nomor seri tidak berasal dari pengiriman penjualan ini.');
+                            }
+                        }
+
+                        ProductSerialNumber::query()
+                            ->whereIn('id', $serialIds)
+                            ->update([
+                                'dispatch_detail_id' => null,
+                                'location_id' => $locationId,
+                                'tax_id' => $taxId,
+                            ]);
+                    }
+                }
+
+                $lockedSaleReturn->forceFill([
+                    'status' => 'Awaiting Settlement',
+                    'received_by' => auth()->id(),
+                    'received_at' => now(),
+                    'settled_at' => null,
+                    'settled_by' => null,
+                ])->save();
+
+                $sale = $lockedSaleReturn->sale()->lockForUpdate()->first();
+                if ($sale) {
+                    $dispatchedQuantity = DispatchDetail::query()
+                        ->where('sale_id', $sale->id)
+                        ->sum('dispatched_quantity');
+
+                    $returnedQuantity = SaleReturnDetail::query()
+                        ->whereHas('saleReturn', function ($query) use ($sale) {
+                            $query->where('sale_id', $sale->id)
+                                ->whereIn('status', ['Awaiting Settlement', 'Completed']);
+                        })
+                        ->sum('quantity');
+
+                    if ($dispatchedQuantity > 0 && $returnedQuantity >= $dispatchedQuantity) {
+                        $sale->status = Sale::STATUS_RETURNED;
+                        $sale->save();
+                    } elseif ($returnedQuantity > 0) {
+                        $sale->status = Sale::STATUS_RETURNED_PARTIALLY;
+                        $sale->save();
+                    }
+                }
+            });
+        } catch (Throwable $e) {
+            Log::error('Gagal menerima retur penjualan', [
+                'sale_return_id' => $sale_return->id,
+                'message' => $e->getMessage(),
+            ]);
+
+            toast('Gagal memproses penerimaan retur penjualan.', 'error');
+
+            return back();
+        }
+
+        toast('Retur penjualan berhasil diterima.', 'success');
+
+        return back();
     }
 }

--- a/Modules/SalesReturn/Resources/views/partials/actions.blade.php
+++ b/Modules/SalesReturn/Resources/views/partials/actions.blade.php
@@ -1,10 +1,13 @@
-@php $approvalStatus = strtolower($data->approval_status ?? ''); @endphp
+@php
+    $approvalStatus = strtolower($data->approval_status ?? '');
+    $status = strtolower($data->status ?? '');
+@endphp
 <div class="btn-group dropleft">
     <button type="button" class="btn btn-ghost-primary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
         <i class="bi bi-three-dots-vertical"></i>
     </button>
     <div class="dropdown-menu dropdown-menu-right shadow-sm">
-        @can('sales.edit')
+        @can('saleReturns.edit')
             @if(in_array($approvalStatus, ['pending', 'draft']))
                 <a href="{{ route('sale-returns.edit', $data->id) }}" class="dropdown-item d-flex align-items-center">
                     <i class="bi bi-pencil text-primary me-2"></i> <span>Edit</span>
@@ -12,10 +15,50 @@
             @endif
         @endcan
 
-        @can('sales.show')
+        @can('saleReturns.approve')
+            @if($approvalStatus === 'pending')
+                <form method="POST" action="{{ route('sale-returns.approve', $data->id) }}" class="m-0">
+                    @csrf
+                    <button type="submit" class="dropdown-item d-flex align-items-center border-0 bg-transparent px-0" onclick="return confirm('Setujui retur penjualan ini?')">
+                        <i class="bi bi-check2-circle text-success me-2"></i> <span>Setujui</span>
+                    </button>
+                </form>
+
+                <a href="#" class="dropdown-item d-flex align-items-center" onclick="event.preventDefault(); saleReturnReject{{ $data->id }}();">
+                    <i class="bi bi-x-circle text-danger me-2"></i> <span>Tolak</span>
+                </a>
+                <form id="sale-return-reject-{{ $data->id }}" method="POST" action="{{ route('sale-returns.reject', $data->id) }}" class="d-none">
+                    @csrf
+                    <input type="hidden" name="reason" value="">
+                </form>
+                <script>
+                    function saleReturnReject{{ $data->id }}() {
+                        const reason = prompt('Masukkan alasan penolakan (opsional):');
+                        if (reason !== null) {
+                            const form = document.getElementById('sale-return-reject-{{ $data->id }}');
+                            form.querySelector('input[name="reason"]').value = reason;
+                            form.submit();
+                        }
+                    }
+                </script>
+            @endif
+        @endcan
+
+        @can('saleReturns.show')
             <a href="{{ route('sale-returns.show', $data->id) }}" class="dropdown-item d-flex align-items-center">
                 <i class="bi bi-eye text-info me-2"></i> <span>Detail</span>
             </a>
+        @endcan
+
+        @can('saleReturns.receive')
+            @if($status === 'awaiting receiving')
+                <form method="POST" action="{{ route('sale-returns.receive', $data->id) }}" class="m-0">
+                    @csrf
+                    <button type="submit" class="dropdown-item d-flex align-items-center border-0 bg-transparent px-0" onclick="return confirm('Terima barang retur ini ke stok?')">
+                        <i class="bi bi-box-arrow-in-down text-primary me-2"></i> <span>Terima Barang</span>
+                    </button>
+                </form>
+            @endif
         @endcan
 
         @can('salePayments.show')
@@ -32,7 +75,7 @@
             @endif
         @endcan
 
-        @can('sales.delete')
+        @can('saleReturns.delete')
             @if(in_array($approvalStatus, ['pending', 'draft']))
                 <button id="delete" type="button" class="dropdown-item d-flex align-items-center" onclick="
                     event.preventDefault();

--- a/Modules/SalesReturn/Resources/views/partials/status.blade.php
+++ b/Modules/SalesReturn/Resources/views/partials/status.blade.php
@@ -8,6 +8,9 @@
     @case('pending')
         <span class="badge bg-warning text-dark text-uppercase">{{ $status ?: 'Pending' }}</span>
         @break
+    @case('awaiting receiving')
+        <span class="badge bg-primary text-uppercase">{{ $status }}</span>
+        @break
     @case('awaiting settlement')
         <span class="badge bg-info text-dark text-uppercase">{{ $status }}</span>
         @break

--- a/Modules/SalesReturn/Resources/views/show.blade.php
+++ b/Modules/SalesReturn/Resources/views/show.blade.php
@@ -1,3 +1,5 @@
+@php($approvalStatus = strtolower($sale_return->approval_status ?? ''))
+@php($status = strtolower($sale_return->status ?? ''))
 @extends('layouts.app')
 
 @section('title', 'Sales Details')
@@ -10,53 +12,132 @@
     </ol>
 @endsection
 
+@can('saleReturns.approve')
+    @if($approvalStatus === 'pending')
+        @push('page_scripts')
+            <script>
+                function saleReturnReject{{ $sale_return->id }}() {
+                    const reason = prompt('Masukkan alasan penolakan (opsional):');
+                    if (reason !== null) {
+                        const form = document.getElementById('sale-return-reject-form-{{ $sale_return->id }}');
+                        form.querySelector('input[name="reason"]').value = reason;
+                        form.submit();
+                    }
+                }
+            </script>
+        @endpush
+    @endif
+@endcan
+
 @section('content')
     @php($customer = optional($sale_return->sale)->customer)
     <div class="container-fluid">
         <div class="row">
             <div class="col-lg-12">
                 <div class="card">
-                    <div class="card-header d-flex flex-wrap align-items-center">
+                    <div class="card-header d-flex flex-wrap align-items-center bg-white border-0">
                         <div>
-                            Reference: <strong>{{ $sale_return->reference }}</strong>
+                            <h4 class="mb-0">Retur Penjualan #{{ $sale_return->reference }}</h4>
+                            <div class="small text-muted">Dibuat pada {{ \Carbon\Carbon::parse($sale_return->date)->translatedFormat('d F Y') }}</div>
                         </div>
-                        <a target="_blank" class="btn btn-sm btn-secondary mfs-auto mfe-1 d-print-none" href="{{ route('sale-returns.pdf', $sale_return->id) }}">
-                            <i class="bi bi-printer"></i> Print
-                        </a>
-                        <a target="_blank" class="btn btn-sm btn-info mfe-1 d-print-none" href="{{ route('sale-returns.pdf', $sale_return->id) }}">
-                            <i class="bi bi-save"></i> Save
-                        </a>
+                        <div class="ms-auto d-flex flex-wrap align-items-center">
+                            <span class="me-2 mb-1">
+                                @include('salesreturn::partials.status', ['data' => $sale_return])
+                            </span>
+                            <span class="me-2 mb-1">
+                                @include('salesreturn::partials.approval-status', ['data' => $sale_return])
+                            </span>
+
+                            @can('saleReturns.edit')
+                                @if(in_array($approvalStatus, ['pending', 'draft']))
+                                    <a class="btn btn-primary btn-sm d-print-none me-2 mb-1" href="{{ route('sale-returns.edit', $sale_return) }}">
+                                        <i class="bi bi-pencil"></i> Edit
+                                    </a>
+                                @endif
+                            @endcan
+
+                            @can('saleReturns.approve')
+                                @if($approvalStatus === 'pending')
+                                    <form method="POST" action="{{ route('sale-returns.approve', $sale_return) }}" class="me-2 mb-1 d-inline">
+                                        @csrf
+                                        <button type="submit" class="btn btn-success btn-sm d-print-none" onclick="return confirm('Setujui retur penjualan ini?')">
+                                            <i class="bi bi-check2-circle"></i> Setujui
+                                        </button>
+                                    </form>
+                                    <form id="sale-return-reject-form-{{ $sale_return->id }}" method="POST" action="{{ route('sale-returns.reject', $sale_return) }}" class="d-none">
+                                        @csrf
+                                        <input type="hidden" name="reason" value="">
+                                    </form>
+                                    <button type="button" class="btn btn-outline-danger btn-sm d-print-none me-2 mb-1" onclick="saleReturnReject{{ $sale_return->id }}()">
+                                        <i class="bi bi-x-circle"></i> Tolak
+                                    </button>
+                                @endif
+                            @endcan
+
+                            @can('saleReturns.receive')
+                                @if($status === 'awaiting receiving')
+                                    <form method="POST" action="{{ route('sale-returns.receive', $sale_return) }}" class="me-2 mb-1 d-inline">
+                                        @csrf
+                                        <button type="submit" class="btn btn-outline-primary btn-sm d-print-none" onclick="return confirm('Terima barang retur ini ke stok?')">
+                                            <i class="bi bi-box-arrow-in-down"></i> Terima Barang
+                                        </button>
+                                    </form>
+                                @endif
+                            @endcan
+
+                            <a target="_blank" class="btn btn-outline-primary btn-sm d-print-none me-2 mb-1" href="{{ route('sale-returns.pdf', $sale_return->id) }}">
+                                <i class="bi bi-printer"></i> Cetak
+                            </a>
+                            <a target="_blank" class="btn btn-outline-secondary btn-sm d-print-none mb-1" href="{{ route('sale-returns.pdf', $sale_return->id) }}">
+                                <i class="bi bi-download"></i> Unduh PDF
+                            </a>
+                        </div>
                     </div>
                     <div class="card-body">
-                        <div class="row mb-4">
-                            <div class="col-sm-4 mb-3 mb-md-0">
-                                <h5 class="mb-2 border-bottom pb-2">Company Info:</h5>
-                                <div><strong>{{ settings()->company_name }}</strong></div>
-                                <div>{{ settings()->company_address }}</div>
-                                <div>Email: {{ settings()->company_email }}</div>
-                                <div>Phone: {{ settings()->company_phone }}</div>
-                            </div>
-
-                            <div class="col-sm-4 mb-3 mb-md-0">
-                                <h5 class="mb-2 border-bottom pb-2">Customer Info:</h5>
-                                <div><strong>{{ $sale_return->customer_name }}</strong></div>
-                                <div>{{ $customer->address ?? '-' }}</div>
-                                <div>Email: {{ $customer->customer_email ?? '-' }}</div>
-                                <div>Phone: {{ $customer->customer_phone ?? '-' }}</div>
-                            </div>
-
-                            <div class="col-sm-4 mb-3 mb-md-0">
-                                <h5 class="mb-2 border-bottom pb-2">Invoice Info:</h5>
-                                <div>Invoice: <strong>INV/{{ $sale_return->reference }}</strong></div>
-                                <div>Date: {{ \Carbon\Carbon::parse($sale_return->date)->format('d M, Y') }}</div>
-                                <div>
-                                    Status: <strong>{{ $sale_return->status }}</strong>
-                                </div>
-                                <div>
-                                    Payment Status: <strong>{{ $sale_return->payment_status }}</strong>
+                        <div class="row g-4 mb-4">
+                            <div class="col-lg-4">
+                                <div class="h-100 border rounded p-3">
+                                    <h6 class="text-uppercase text-muted small mb-3">Perusahaan</h6>
+                                    <p class="mb-1 fw-semibold">{{ settings()->company_name }}</p>
+                                    <p class="mb-1">{{ settings()->company_address }}</p>
+                                    <p class="mb-1">Email: {{ settings()->company_email }}</p>
+                                    <p class="mb-0">Telepon: {{ settings()->company_phone }}</p>
                                 </div>
                             </div>
 
+                            <div class="col-lg-4">
+                                <div class="h-100 border rounded p-3">
+                                    <h6 class="text-uppercase text-muted small mb-3">Pelanggan</h6>
+                                    <p class="mb-1 fw-semibold">{{ $sale_return->customer_name }}</p>
+                                    <p class="mb-1">{{ $customer->address ?? '-' }}</p>
+                                    <p class="mb-1">Email: {{ $customer->customer_email ?? '-' }}</p>
+                                    <p class="mb-0">Telepon: {{ $customer->customer_phone ?? '-' }}</p>
+                                </div>
+                            </div>
+
+                            <div class="col-lg-4">
+                                <div class="h-100 border rounded p-3">
+                                    <h6 class="text-uppercase text-muted small mb-3">Ringkasan Dokumen</h6>
+                                    <dl class="row mb-0 small">
+                                        <dt class="col-5 text-muted">Invoice</dt>
+                                        <dd class="col-7 fw-semibold">INV/{{ $sale_return->reference }}</dd>
+                                        <dt class="col-5 text-muted">Referensi Penjualan</dt>
+                                        <dd class="col-7 fw-semibold">{{ $sale_return->sale_reference ?? '-' }}</dd>
+                                        <dt class="col-5 text-muted">Lokasi</dt>
+                                        <dd class="col-7 fw-semibold">{{ optional($sale_return->location)->name ?? '-' }}</dd>
+                                        <dt class="col-5 text-muted">Status Pembayaran</dt>
+                                        <dd class="col-7 fw-semibold">{{ $sale_return->payment_status }}</dd>
+                                        @if($sale_return->received_at)
+                                            <dt class="col-5 text-muted">Diterima</dt>
+                                            <dd class="col-7 fw-semibold">{{ $sale_return->received_at->translatedFormat('d F Y H:i') }} oleh {{ optional($sale_return->receivedBy)->name ?? '-' }}</dd>
+                                        @endif
+                                        @if($sale_return->rejection_reason)
+                                            <dt class="col-5 text-muted">Alasan Penolakan</dt>
+                                            <dd class="col-7">{{ $sale_return->rejection_reason }}</dd>
+                                        @endif
+                                    </dl>
+                                </div>
+                            </div>
                         </div>
 
                         <div class="table-responsive-sm">

--- a/Modules/SalesReturn/Routes/web.php
+++ b/Modules/SalesReturn/Routes/web.php
@@ -25,6 +25,13 @@ Route::group(['middleware' => ['auth', 'role.setting']], function () {
         return $pdf->stream('sale-return-'. $saleReturn->reference .'.pdf');
     })->name('sale-returns.pdf');
 
+    Route::post('sale-returns/{sale_return}/approve', 'SalesReturnController@approve')
+        ->name('sale-returns.approve');
+    Route::post('sale-returns/{sale_return}/reject', 'SalesReturnController@reject')
+        ->name('sale-returns.reject');
+    Route::post('sale-returns/{sale_return}/receive', 'SalesReturnController@receive')
+        ->name('sale-returns.receive');
+
     //Sale Returns
     Route::resource('sale-returns', 'SalesReturnController');
 

--- a/Modules/User/Database/Seeders/PermissionsTableSeeder.php
+++ b/Modules/User/Database/Seeders/PermissionsTableSeeder.php
@@ -209,6 +209,8 @@ class PermissionsTableSeeder extends Seeder
             'saleReturns.edit',
             'saleReturns.delete',
             'saleReturns.show',
+            'saleReturns.approve',
+            'saleReturns.receive',
             'sales.access',
             'sales.create',
             'sales.edit',

--- a/Modules/User/Resources/views/roles/create.blade.php
+++ b/Modules/User/Resources/views/roles/create.blade.php
@@ -73,6 +73,8 @@
                                             'saleReturns.edit'   => 'Ubah',
                                             'saleReturns.delete' => 'Hapus',
                                             'saleReturns.show'   => 'Lihat',
+                                            'saleReturns.approve' => 'Persetujuan',
+                                            'saleReturns.receive' => 'Penerimaan',
                                         ],
 
                                         'Pembayaran Penjualan' => [

--- a/Modules/User/Resources/views/roles/edit.blade.php
+++ b/Modules/User/Resources/views/roles/edit.blade.php
@@ -72,6 +72,8 @@
                                             'saleReturns.edit'   => 'Ubah',
                                             'saleReturns.delete' => 'Hapus',
                                             'saleReturns.show'   => 'Lihat',
+                                            'saleReturns.approve' => 'Persetujuan',
+                                            'saleReturns.receive' => 'Penerimaan',
                                         ],
 
                                         'Pembayaran Penjualan' => [


### PR DESCRIPTION
## Summary
- add approve, reject, and receive actions for sales returns while updating stock, serial numbers, and sale status
- record receiving audit data, expose new status badges, and surface approve/receive controls in the UI
- seed new permissions, add role toggles, and create a migration for received_by/received_at columns

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e275ed68208326a51564889e90bd13