### PR TITLE
Remove Scout trait usage from product entity

### DIFF
--- a/Modules/Product/Entities/Product.php
+++ b/Modules/Product/Entities/Product.php
@@ -6,7 +6,6 @@ use App\Models\BaseModel;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
-use Laravel\Scout\Searchable;
 use Modules\Setting\Entities\Setting;
 use Modules\Setting\Entities\Tax;
 use Modules\Setting\Entities\Unit;
@@ -17,7 +16,7 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class Product extends BaseModel implements HasMedia
 {
-    use InteractsWithMedia, Searchable;
+    use InteractsWithMedia;
 
     protected $guarded = [];
 


### PR DESCRIPTION
## Summary
- stop importing Laravel Scout's Searchable trait in the product entity
- keep the Algolia reindex helpers while dropping the unused trait

## Testing
- php -l Modules/Product/Entities/Product.php

------
https://chatgpt.com/codex/tasks/task_e_68e327f130f88326a654a776250a344a