### PR TITLE
Allow supplier autocomplete to match contact names

### DIFF
--- a/app/Livewire/AutoComplete/SupplierLoader.php
+++ b/app/Livewire/AutoComplete/SupplierLoader.php
@@ -71,11 +71,13 @@ class SupplierLoader extends Component
     {
         if ($this->query) {
             $this->query_count = Supplier::where(function ($query) {
-                $query->where('supplier_name', 'like', '%' . $this->query . '%');
+                $query->where('supplier_name', 'like', '%' . $this->query . '%')
+                    ->orWhere('contact_name', 'like', '%' . $this->query . '%');
             })
                 ->count();
             $this->search_results = Supplier::where(function ($query) {
-                $query->where('supplier_name', 'like', '%' . $this->query . '%');
+                $query->where('supplier_name', 'like', '%' . $this->query . '%')
+                    ->orWhere('contact_name', 'like', '%' . $this->query . '%');
             })
                 ->limit($this->how_many)
                 ->get();

--- a/resources/views/livewire/auto-complete/supplier-loader.blade.php
+++ b/resources/views/livewire/auto-complete/supplier-loader.blade.php
@@ -32,6 +32,9 @@
                         @foreach($search_results as $result)
                             <li class="list-group-item list-group-item-action">
                                 <a wire:click.prevent="selectSupplier({{ $result->id }})" href="#">
+                                    @if($result->contact_name)
+                                        {{ $result->contact_name }} —
+                                    @endif
                                     {{ $result->supplier_name }}
                                 </a>
                             </li>


### PR DESCRIPTION
## Summary
- allow the supplier autocomplete to search by contact name as well as company name
- show the supplier contact name alongside the company in the autocomplete results so matches are clear

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e479eecf0c8326a0f192979f3fb307