### PR TITLE
Normalize expense detail tax IDs before persistence

### DIFF
--- a/app/Livewire/Expense/ExpenseForm.php
+++ b/app/Livewire/Expense/ExpenseForm.php
@@ -93,7 +93,13 @@ class ExpenseForm extends Component
         $normalized = [];
         foreach ($this->details as $row) {
             $amount = floatval(preg_replace('/[^0-9]/', '', $row['amount']));
-            $normalized[] = array_merge($row, ['amount' => $amount]);
+            $taxId = $row['tax_id'] ?? null;
+            $taxId = empty($taxId) ? null : (int) $taxId;
+
+            $normalized[] = array_merge($row, [
+                'amount' => $amount,
+                'tax_id' => $taxId,
+            ]);
         }
         $this->details = $normalized;
     }

--- a/tests/Feature/ExpenseFormTest.php
+++ b/tests/Feature/ExpenseFormTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Livewire\Expense\ExpenseForm;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Modules\Expense\Entities\ExpenseCategory;
+use Modules\Expense\Entities\ExpenseDetail;
+use Tests\TestCase;
+
+class ExpenseFormTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_expense_detail_without_tax_is_saved_with_null_tax_id(): void
+    {
+        $category = ExpenseCategory::create([
+            'category_name' => 'Travel',
+        ]);
+
+        Livewire::test(ExpenseForm::class)
+            ->set('category_id', $category->id)
+            ->set('details', [
+                [
+                    'name' => 'Plane Ticket',
+                    'tax_id' => '',
+                    'amount' => '150000',
+                ],
+            ])
+            ->call('save');
+
+        $detail = ExpenseDetail::first();
+
+        $this->assertNotNull($detail, 'Expense detail should be persisted.');
+        $this->assertNull($detail->tax_id, 'Tax identifier should be stored as NULL when not provided.');
+    }
+}
+


### PR DESCRIPTION
## Summary
- normalize expense detail tax selections so blank values persist as null and valid selections as integers
- add a feature test covering expenses saved without a tax selection on a detail row

## Testing
- `composer install` *(fails: locked dependencies require PHP <= 8.3 while the environment provides PHP 8.4.12)*

------
https://chatgpt.com/codex/tasks/task_e_68e47f8e5c808326a742d097aea68970