### PR TITLE
Refactor expense edit flow to Livewire

### DIFF
--- a/Modules/Expense/Resources/views/expenses/edit.blade.php
+++ b/Modules/Expense/Resources/views/expenses/edit.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 
-@section('title', 'Buat Biaya')
+@section('title', 'Edit Biaya')
 
 @section('breadcrumb')
     <ol class="breadcrumb border-0 m-0">
@@ -12,81 +12,6 @@
 
 @section('content')
     <div class="container-fluid">
-        <form id="expense-form" action="{{ route('expenses.update', $expense) }}" method="POST">
-            @csrf
-            @method('patch')
-            <div class="row">
-                <div class="col-lg-12">
-                    @include('utils.alerts')
-                    <div class="form-group">
-                        <button class="btn btn-primary">Ubah Biaya <i class="bi bi-check"></i></button>
-                    </div>
-                </div>
-                <div class="col-lg-12">
-                    <div class="card">
-                        <div class="card-body">
-                            <div class="form-row">
-                                <div class="col-lg-6">
-                                    <div class="form-group">
-                                        <label for="reference">Referensi <span class="text-danger">*</span></label>
-                                        <input type="text" class="form-control" name="reference" required value="{{ $expense->reference }}" readonly>
-                                    </div>
-                                </div>
-                                <div class="col-lg-6">
-                                    <div class="form-group">
-                                        <label for="date">Tanggal <span class="text-danger">*</span></label>
-                                        <input type="date" class="form-control" name="date" required value="{{ $expense->getAttributes()['date'] }}">
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="form-row">
-                                <div class="col-lg-6">
-                                    <div class="form-group">
-                                        <label for="category_id">Kategori <span class="text-danger">*</span></label>
-                                        <select name="category_id" id="category_id" class="form-control" required>
-                                            @foreach(\Modules\Expense\Entities\ExpenseCategory::all() as $category)
-                                                <option {{ $category->id == $expense->category_id ? 'selected' : '' }} value="{{ $category->id }}">{{ $category->category_name }}</option>
-                                            @endforeach
-                                        </select>
-                                    </div>
-                                </div>
-                                <div class="col-lg-6">
-                                    <div class="form-group">
-                                        <label for="amount">Jumlah <span class="text-danger">*</span></label>
-                                        <input id="amount" type="text" class="form-control" name="amount" required value="{{ $expense->amount }}">
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="form-group">
-                                <label for="details">Rincian</label>
-                                <textarea class="form-control" rows="6" name="details">{{ $expense->details }}</textarea>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </form>
+        <livewire:expense.expense-form :expense="$expense" />
     </div>
 @endsection
-
-@push('page_scripts')
-    <script src="{{ asset('js/jquery-mask-money.js') }}"></script>
-    <script>
-        $(document).ready(function () {
-            $('#amount').maskMoney({
-                prefix:'{{ settings()->currency->symbol }}',
-                thousands:'{{ settings()->currency->thousand_separator }}',
-                decimal:'{{ settings()->currency->decimal_separator }}',
-            });
-
-            $('#amount').maskMoney('mask');
-
-            $('#expense-form').submit(function () {
-                var amount = $('#amount').maskMoney('unmasked')[0];
-                $('#amount').val(amount);
-            });
-        });
-    </script>
-@endpush

--- a/resources/views/livewire/expense/expense-form.blade.php
+++ b/resources/views/livewire/expense/expense-form.blade.php
@@ -1,7 +1,10 @@
 <div>
     <form wire:submit.prevent="save" enctype="multipart/form-data">
         <div class="d-flex justify-content-end mb-3">
-            <button class="btn btn-primary">Simpan Biaya <i class="bi bi-check"></i></button>
+            <button class="btn btn-primary">
+                {{ $expenseId ? 'Ubah Biaya' : 'Simpan Biaya' }}
+                <i class="bi bi-check"></i>
+            </button>
         </div>
 
         <div class="card mb-4">
@@ -49,7 +52,7 @@
                     </thead>
                     <tbody>
                     @foreach($details as $index => $row)
-                        <tr>
+                        <tr wire:key="detail-{{ $row['id'] ?? 'new-'.$index }}">
                             <td>
                                 <input type="text" class="form-control" wire:model="details.{{ $index }}.name">
                                 @error("details.$index.name") <span class="text-danger small">{{ $message }}</span> @enderror
@@ -124,11 +127,34 @@
                 <input type="file" class="form-control" wire:model="files" multiple>
                 @error('files.*') <span class="text-danger">{{ $message }}</span> @enderror
                 <div wire:loading wire:target="files" class="text-info mt-2">Mengunggah file...</div>
+
+                @if(!empty($existingAttachments))
+                    <div class="mt-3">
+                        <label class="form-label">Lampiran Saat Ini</label>
+                        <ul class="list-group">
+                            @foreach($existingAttachments as $attachment)
+                                <li class="list-group-item d-flex justify-content-between align-items-center"
+                                    wire:key="attachment-{{ $attachment['id'] }}">
+                                    <span>
+                                        {{ $attachment['name'] }}
+                                        <small class="text-muted">({{ $attachment['size'] }})</small>
+                                    </span>
+                                    <button type="button" class="btn btn-sm btn-outline-danger"
+                                            wire:click="removeExistingAttachment({{ $attachment['id'] }})">
+                                        Hapus
+                                    </button>
+                                </li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
             </div>
         </div>
 
         <div class="form-group">
-            <button class="btn btn-success">Simpan</button>
+            <button class="btn btn-success">
+                {{ $expenseId ? 'Perbarui' : 'Simpan' }}
+            </button>
         </div>
     </form>
 </div>

--- a/tests/Feature/ExpenseFormTest.php
+++ b/tests/Feature/ExpenseFormTest.php
@@ -3,10 +3,14 @@
 namespace Tests\Feature;
 
 use App\Livewire\Expense\ExpenseForm;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
 use Livewire\Livewire;
+use Modules\Expense\Entities\Expense;
 use Modules\Expense\Entities\ExpenseCategory;
 use Modules\Expense\Entities\ExpenseDetail;
+use Modules\Setting\Entities\Tax;
 use Tests\TestCase;
 
 class ExpenseFormTest extends TestCase
@@ -34,6 +38,90 @@ class ExpenseFormTest extends TestCase
 
         $this->assertNotNull($detail, 'Expense detail should be persisted.');
         $this->assertNull($detail->tax_id, 'Tax identifier should be stored as NULL when not provided.');
+    }
+
+    public function test_editing_expense_updates_rows_taxes_and_total(): void
+    {
+        Storage::fake('public');
+
+        $category = ExpenseCategory::create([
+            'category_name' => 'Travel',
+        ]);
+
+        $tax = Tax::create([
+            'name' => 'VAT 10%',
+            'value' => 10,
+        ]);
+
+        $expense = Expense::create([
+            'category_id' => $category->id,
+            'date' => now()->format('Y-m-d'),
+            'amount' => 110000,
+        ]);
+
+        $detailWithTax = $expense->details()->create([
+            'name' => 'Initial Taxi',
+            'tax_id' => $tax->id,
+            'amount' => 50000,
+        ]);
+
+        $detailWithoutTax = $expense->details()->create([
+            'name' => 'Initial Meal',
+            'tax_id' => null,
+            'amount' => 50000,
+        ]);
+
+        $existingAttachment = UploadedFile::fake()->create('old-receipt.pdf', 10, 'application/pdf');
+        $expense->addMedia($existingAttachment)->toMediaCollection('attachments');
+        $existingMediaId = $expense->getMedia('attachments')->first()->id;
+
+        $newAttachment = UploadedFile::fake()->create('new-receipt.pdf', 12, 'application/pdf');
+
+        Livewire::test(ExpenseForm::class, ['expense' => $expense->fresh('details', 'media')])
+            ->set('details', [
+                [
+                    'id' => $detailWithTax->id,
+                    'name' => 'Taxi Ride',
+                    'tax_id' => $tax->id,
+                    'amount' => '75000',
+                ],
+                [
+                    'name' => 'Hotel Stay',
+                    'tax_id' => null,
+                    'amount' => '125000',
+                ],
+            ])
+            ->set('files', [$newAttachment])
+            ->call('removeExistingAttachment', $existingMediaId)
+            ->call('save')
+            ->assertRedirect(route('expenses.index'));
+
+        $expense->refresh();
+
+        $this->assertSame(2, $expense->details()->count());
+
+        $this->assertDatabaseHas('expense_details', [
+            'id' => $detailWithTax->id,
+            'name' => 'Taxi Ride',
+            'tax_id' => $tax->id,
+            'amount' => 75000.00,
+        ]);
+
+        $this->assertDatabaseMissing('expense_details', [
+            'id' => $detailWithoutTax->id,
+        ]);
+
+        $this->assertDatabaseHas('expense_details', [
+            'expense_id' => $expense->id,
+            'name' => 'Hotel Stay',
+            'tax_id' => null,
+            'amount' => 125000.00,
+        ]);
+
+        $this->assertEquals(207500.0, $expense->amount);
+
+        $this->assertCount(1, $expense->getMedia('attachments'));
+        $this->assertEquals('new-receipt.pdf', $expense->getMedia('attachments')->first()->file_name);
     }
 }
 


### PR DESCRIPTION
## Summary
- reuse the expense Livewire form for editing by hydrating existing details, tax selections, and attachments
- synchronize expense details and attachments during updates while recalculating totals with cached tax rates
- expand feature coverage to assert expense edits update rows, totals, and uploaded files

## Testing
- unable to run tests: `composer install` fails on PHP 8.4 dependency constraints

------
https://chatgpt.com/codex/tasks/task_e_68e4877ea5dc8326b9d1210ac968a7cb