### PR TITLE
Handle POS bundle selection before serial flows

### DIFF
--- a/app/Livewire/Pos/SerialNumberPicker.php
+++ b/app/Livewire/Pos/SerialNumberPicker.php
@@ -11,6 +11,12 @@ class SerialNumberPicker extends Component
     /** Target product */
     public ?int $productId = null;
 
+    /** Optional bundle context */
+    public ?array $bundle = null;
+
+    /** Expected serial count (from conversion factor) */
+    public ?int $expectedCount = null;
+
     /** Modal visibility */
     public bool $show = false;
 
@@ -34,9 +40,18 @@ class SerialNumberPicker extends Component
     }
 
     /** Open from parent: $dispatch('openSerialPicker', productId) */
-    public function open(int $productId): void
+    public function open($payload): void
     {
-        $this->productId = $productId;
+        if (is_array($payload)) {
+            $this->productId    = isset($payload['product_id']) ? (int) $payload['product_id'] : $this->productId;
+            $this->expectedCount = isset($payload['expected_count']) ? (int) $payload['expected_count'] : null;
+            $this->bundle       = $payload['bundle'] ?? null;
+        } else {
+            $this->productId    = (int) $payload;
+            $this->expectedCount = null;
+            $this->bundle       = null;
+        }
+
         $this->show = true;
 
         // Let the browser focus the input as soon as modal is visible
@@ -47,6 +62,8 @@ class SerialNumberPicker extends Component
     {
         $this->show = false;
         $this->scan = '';
+        $this->bundle = null;
+        $this->expectedCount = null;
     }
 
     public function render()
@@ -107,6 +124,7 @@ class SerialNumberPicker extends Component
                     'id' => (int)$row->id,
                     'serial_number' => (string)$row->serial_number,
                 ],
+                'bundle' => $this->bundle,
             ]);
 
             // UX: show as "recent", clear input, keep modal open for next scan

--- a/app/Support/ProductBundleResolver.php
+++ b/app/Support/ProductBundleResolver.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Collection;
+use Modules\Product\Entities\ProductBundle;
+
+/**
+ * Small helper responsible for hydrating bundle information for a product.
+ */
+class ProductBundleResolver
+{
+    /**
+     * Fetch all bundles that belong to the given product, eager loading items & products.
+     */
+    public static function forProduct(int $productId): Collection
+    {
+        return ProductBundle::with('items.product')
+            ->where('parent_product_id', $productId)
+            ->get();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a reusable ProductBundleResolver helper to hydrate bundle options for POS selections
- update Checkout to prompt for bundle choices, support skipping bundles, and carry bundle data through serial scanning flows
- route exact serial scans through the same bundle logic and pass bundle context to the serial picker component

## Testing
- php -l app/Livewire/Pos/Checkout.php
- php -l app/Livewire/SearchProduct.php
- php -l app/Livewire/Pos/SerialNumberPicker.php
- php -l app/Support/ProductBundleResolver.php

------
https://chatgpt.com/codex/tasks/task_e_68e4c548d1688326ae9783fd124917f6