### PR TITLE
Enhance checkout cart pricing metadata

### DIFF
--- a/resources/views/livewire/includes/product-cart-quantity.blade.php
+++ b/resources/views/livewire/includes/product-cart-quantity.blade.php
@@ -1,9 +1,13 @@
+@php
+    $cartOptions = $cart_item->options->toArray();
+    $cartKey = $cartOptions['cart_key'] ?? $cart_item->id;
+@endphp
 <div class="input-group d-flex justify-content-center">
-    <input wire:model="quantity.{{ $cart_item->id }}"
+    <input wire:model="quantity.{{ $cartKey }}"
            style="min-width: 40px; max-width: 90px;"
            type="number"
            class="form-control text-right"
            value="{{ $cart_item->qty }}"
            min="1"
-           wire:blur="updateQuantity('{{ $cart_item->rowId }}', {{ $cart_item->id }})">
+           wire:blur="updateQuantity('{{ $cart_item->rowId }}', '{{ $cartKey }}')">
 </div>

--- a/resources/views/livewire/pos/checkout.blade.php
+++ b/resources/views/livewire/pos/checkout.blade.php
@@ -81,17 +81,47 @@
             <div>
                 @if($cart_items->isNotEmpty())
                     @foreach($cart_items as $cart_item)
+                        @php
+                            $options = $cart_item->options->toArray();
+                            $cartKey = $options['cart_key'] ?? $cart_item->id;
+                            $lineTotal = data_get($options, 'sub_total', $cart_item->price * $cart_item->qty);
+                            $bundleName = data_get($options, 'bundle_name');
+                            $bundleItems = data_get($options, 'bundle_items', []);
+                        @endphp
                         <div class="d-block d-md-none cart-card">
                             <div class="row">
                                 <div class="col-6 cart-label">Produk</div>
                                 <div class="col-6">
                                     {{ $cart_item->name }}<br>
                                     <span class="badge badge-success">{{ $cart_item->options->code }}</span>
+                                    @if(!empty($bundleName))
+                                        <div class="small text-muted">Bundle: {{ $bundleName }}</div>
+                                    @endif
+                                    @if(!empty($bundleItems))
+                                        <ul class="mb-0 mt-2 pl-3 small">
+                                            @foreach($bundleItems as $bundleItem)
+                                                @php
+                                                    $bundleItem = is_array($bundleItem) ? $bundleItem : (array) $bundleItem;
+                                                    $lineQty = $bundleItem['line_quantity'] ?? ($cart_item->qty * ($bundleItem['quantity_per_bundle'] ?? 0));
+                                                $lineQtyDisplay = rtrim(rtrim(number_format($lineQty, 2, '.', ''), '0'), '.');
+                                            @endphp
+                                            <li class="mb-1">
+                                                <div><strong>{{ $bundleItem['name'] ?? 'Bundle Item' }}</strong></div>
+                                                <div class="text-muted">
+                                                        {{ $lineQtyDisplay }} × {{ format_currency($bundleItem['price'] ?? 0) }}
+                                                        (= {{ format_currency($bundleItem['sub_total'] ?? 0) }})
+                                                        <br>
+                                                        <small>{{ $bundleItem['quantity_per_bundle'] ?? 0 }} per bundle</small>
+                                                </div>
+                                                </li>
+                                            @endforeach
+                                        </ul>
+                                    @endif
                                 </div>
                             </div>
                             <div class="row">
                                 <div class="col-6 cart-label">Harga</div>
-                                <div class="col-6">{{ format_currency($cart_item->price) }}</div>
+                                <div class="col-6">{{ format_currency($lineTotal) }}</div>
                             </div>
                             <div class="row">
                                 <div class="col-6 cart-label">Jumlah</div>
@@ -105,9 +135,9 @@
                                     @else
                                         @include('livewire.includes.product-cart-quantity')
                                     @endif
-                                    @if(!empty($conversion_breakdowns[$cart_item->id]))
+                                    @if(!empty($conversion_breakdowns[$cartKey] ?? ''))
                                         <small class="text-muted">
-                                            ({{ $conversion_breakdowns[$cart_item->id] }})
+                                            ({{ $conversion_breakdowns[$cartKey] }})
                                         </small>
                                     @endif
                                     @if(($cart_item->options->serial_number_required ?? false))
@@ -161,30 +191,60 @@
                     </thead>
                     <tbody>
                     @if($cart_items->isNotEmpty())
-                        @foreach($cart_items as $cart_item)
-                            <tr>
-                                <td class="align-middle">
-                                    {{ $cart_item->name }} <br>
-                                    <span class="badge badge-success">{{ $cart_item->options->code }}</span>
-                                </td>
-                                <td class="align-middle">{{ format_currency($cart_item->price) }}</td>
-                                <td class="align-middle">
-                                    @if(($cart_item->options->serial_number_required ?? false))
-                                        {{-- Read-only qty derived from serial count --}}
-                                        <div class="d-inline-flex align-items-center">
-                                            <span class="badge badge-secondary mr-2">Qty</span>
+                    @foreach($cart_items as $cart_item)
+                        @php
+                            $options = $cart_item->options->toArray();
+                            $cartKey = $options['cart_key'] ?? $cart_item->id;
+                            $lineTotal = data_get($options, 'sub_total', $cart_item->price * $cart_item->qty);
+                            $bundleName = data_get($options, 'bundle_name');
+                            $bundleItems = data_get($options, 'bundle_items', []);
+                        @endphp
+                        <tr>
+                            <td class="align-middle">
+                                {{ $cart_item->name }} <br>
+                                <span class="badge badge-success">{{ $cart_item->options->code }}</span>
+                                @if(!empty($bundleName))
+                                    <div class="small text-muted">Bundle: {{ $bundleName }}</div>
+                                @endif
+                                @if(!empty($bundleItems))
+                                    <ul class="mb-0 mt-2 pl-3 small">
+                                        @foreach($bundleItems as $bundleItem)
+                                            @php
+                                                $bundleItem = is_array($bundleItem) ? $bundleItem : (array) $bundleItem;
+                                                $lineQty = $bundleItem['line_quantity'] ?? ($cart_item->qty * ($bundleItem['quantity_per_bundle'] ?? 0));
+                                                $lineQtyDisplay = rtrim(rtrim(number_format($lineQty, 2, '.', ''), '0'), '.');
+                                            @endphp
+                                            <li class="mb-1">
+                                                <div><strong>{{ $bundleItem['name'] ?? 'Bundle Item' }}</strong></div>
+                                                <div class="text-muted">
+                                                    {{ $lineQtyDisplay }} × {{ format_currency($bundleItem['price'] ?? 0) }}
+                                                    (= {{ format_currency($bundleItem['sub_total'] ?? 0) }})
+                                                    <br>
+                                                    <small>{{ $bundleItem['quantity_per_bundle'] ?? 0 }} per bundle</small>
+                                                </div>
+                                            </li>
+                                        @endforeach
+                                    </ul>
+                                @endif
+                            </td>
+                            <td class="align-middle">{{ format_currency($lineTotal) }}</td>
+                            <td class="align-middle">
+                                @if(($cart_item->options->serial_number_required ?? false))
+                                    {{-- Read-only qty derived from serial count --}}
+                                    <div class="d-inline-flex align-items-center">
+                                        <span class="badge badge-secondary mr-2">Qty</span>
                                             <strong>{{ $cart_item->qty }}</strong>
                                         </div>
-                                    @else
-                                        @include('livewire.includes.product-cart-quantity')
-                                    @endif
-                                    @if(!empty($conversion_breakdowns[$cart_item->id]))
-                                        <small class="text-muted">({{ $conversion_breakdowns[$cart_item->id] }})</small>
-                                    @endif
-                                    @if(($cart_item->options->serial_number_required ?? false))
-                                        @php $serials = $cart_item->options->serial_numbers ?? []; @endphp
-                                        @if(!empty($serials))
-                                            <div class="mt-2">
+                                @else
+                                    @include('livewire.includes.product-cart-quantity')
+                                @endif
+                                @if(!empty($conversion_breakdowns[$cartKey] ?? ''))
+                                    <small class="text-muted">({{ $conversion_breakdowns[$cartKey] }})</small>
+                                @endif
+                                @if(($cart_item->options->serial_number_required ?? false))
+                                    @php $serials = $cart_item->options->serial_numbers ?? []; @endphp
+                                    @if(!empty($serials))
+                                        <div class="mt-2">
                                                 @foreach($serials as $sn)
                                                     @php $snStr = is_array($sn) ? ($sn['serial_number'] ?? '') : (string)$sn; @endphp
                                                     <span class="badge badge-info badge-pill mr-1 mb-1">


### PR DESCRIPTION
## Summary
- persist product identifiers, sale price, conversion context, and bundle pricing metadata on every cart line so totals can be reused without recalculation
- recalculate cart options when quantities or serial selections change to keep bundle subtotals and conversion breakdowns in sync
- refresh the POS checkout view to display stored line totals, bundle names, and nested bundle item costs

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4cb623fc4832686edaeba921ba150