### PR TITLE
Ensure POS sales use location-aware tax handling

### DIFF
--- a/app/Support/PosLocationResolver.php
+++ b/app/Support/PosLocationResolver.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Facades\Cache;
+use Modules\Setting\Entities\Location;
+
+class PosLocationResolver
+{
+    /**
+     * Resolve the POS-enabled location ID for the current setting context.
+     */
+    public static function resolveId(?int $settingId = null): ?int
+    {
+        $settingId ??= session('setting_id');
+
+        if (!$settingId) {
+            return null;
+        }
+
+        $cacheKey = "pos_location_id_{$settingId}";
+
+        return Cache::remember($cacheKey, now()->addMinutes(5), function () use ($settingId) {
+            return Location::query()
+                ->where('setting_id', $settingId)
+                ->where('is_pos', true)
+                ->value('id');
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable POS location resolver so controllers and Livewire components share the same lookup logic
- update the POS checkout flow to allocate stock per location, capture tax-free vs taxed quantities, and carry serial tax metadata into the cart
- adjust the POS controller to lock and decrement location stock, persist resolved tax IDs on sale details/bundle items, and mark serial numbers as dispatched

## Testing
- `php -l app/Livewire/Pos/Checkout.php`
- `php -l Modules/Sale/Http/Controllers/PosController.php`
- `php -l app/Support/PosLocationResolver.php`

------
https://chatgpt.com/codex/tasks/task_e_68e4d51573c08326a6052d7fabcdb83f