### PR TITLE
Enhance POS checkout payment interactions

### DIFF
--- a/Modules/Sale/Http/Controllers/PosController.php
+++ b/Modules/Sale/Http/Controllers/PosController.php
@@ -182,7 +182,9 @@ class PosController extends Controller
 
         $cart->destroy();
 
-        return redirect()->route('sales.index')->with('message', 'Quotation created successfully!');
+        toast('Dokumen penjualan disimpan sebagai draft!', 'success');
+
+        return redirect()->route('app.pos.index');
     }
 
     private function persistSaleDetailsFromCart(Sale $sale, $cartItems, bool $adjustInventory, ?int $posLocationId = null): void

--- a/Modules/Sale/Resources/views/pos/index.blade.php
+++ b/Modules/Sale/Resources/views/pos/index.blade.php
@@ -33,33 +33,56 @@
 @push('page_scripts')
     <script src="{{ asset('js/jquery-mask-money.js') }}"></script>
     <script>
+        function initPosCheckoutMaskMoney() {
+            const $paidAmount = $('#paid_amount');
+            const $totalAmount = $('#total_amount');
+
+            if (!$paidAmount.length || typeof $paidAmount.maskMoney !== 'function') {
+                return;
+            }
+
+            if ($paidAmount.data('maskMoney')) {
+                try { $paidAmount.maskMoney('destroy'); } catch (e) {}
+            }
+
+            if ($totalAmount.length && $totalAmount.data('maskMoney')) {
+                try { $totalAmount.maskMoney('destroy'); } catch (e) {}
+            }
+
+            $paidAmount.maskMoney({
+                prefix:'{{ settings()->currency->symbol }}',
+                thousands:'{{ settings()->currency->thousand_separator }}',
+                decimal:'{{ settings()->currency->decimal_separator }}',
+                allowZero: false,
+            });
+
+            $totalAmount.maskMoney({
+                prefix:'{{ settings()->currency->symbol }}',
+                thousands:'{{ settings()->currency->thousand_separator }}',
+                decimal:'{{ settings()->currency->decimal_separator }}',
+                allowZero: true,
+            });
+
+            $paidAmount.maskMoney('mask');
+            $totalAmount.maskMoney('mask');
+        }
+
         $(document).ready(function () {
-            window.addEventListener('showCheckoutModal', event => {
+            window.addEventListener('showCheckoutModal', () => {
                 $('#checkoutModal').modal('show');
 
-                $('#paid_amount').maskMoney({
-                    prefix:'{{ settings()->currency->symbol }}',
-                    thousands:'{{ settings()->currency->thousand_separator }}',
-                    decimal:'{{ settings()->currency->decimal_separator }}',
-                    allowZero: false,
-                });
+                initPosCheckoutMaskMoney();
 
-                $('#total_amount').maskMoney({
-                    prefix:'{{ settings()->currency->symbol }}',
-                    thousands:'{{ settings()->currency->thousand_separator }}',
-                    decimal:'{{ settings()->currency->decimal_separator }}',
-                    allowZero: true,
+                $('#checkout-form').off('submit.pos').on('submit.pos', function () {
+                    const paidAmount = $('#paid_amount').maskMoney('unmasked')[0];
+                    $('#paid_amount').val(paidAmount);
+                    const totalAmount = $('#total_amount').maskMoney('unmasked')[0];
+                    $('#total_amount').val(totalAmount);
                 });
+            });
 
-                $('#paid_amount').maskMoney('mask');
-                $('#total_amount').maskMoney('mask');
-
-                $('#checkout-form').submit(function () {
-                    var paid_amount = $('#paid_amount').maskMoney('unmasked')[0];
-                    $('#paid_amount').val(paid_amount);
-                    var total_amount = $('#total_amount').maskMoney('unmasked')[0];
-                    $('#total_amount').val(total_amount);
-                });
+            window.addEventListener('pos-mask-money-init', () => {
+                initPosCheckoutMaskMoney();
             });
         });
     </script>

--- a/resources/views/livewire/pos/includes/checkout-modal.blade.php
+++ b/resources/views/livewire/pos/includes/checkout-modal.blade.php
@@ -46,7 +46,7 @@
                                         <label for="paid_amount">Received Amount <span
                                                 class="text-danger">*</span></label>
                                         <input id="paid_amount" type="text" class="form-control" name="paid_amount"
-                                               value="{{ $total_amount }}" required>
+                                               wire:model.live.debounce.300ms="paid_amount" required>
                                     </div>
                                 </div>
                             </div>
@@ -91,7 +91,20 @@
                                     <tr class="text-primary">
                                         <th>Grand Total</th>
                                         <th>
-                                            (=) {{ format_currency(Cart::instance($cart_instance)->total()) }}
+                                            (=) {{ format_currency($total_amount) }}
+                                        </th>
+                                    </tr>
+                                    <tr>
+                                        <th>Received Amount</th>
+                                        <td>
+                                            {{ format_currency($paidAmount ?? 0) }}
+                                        </td>
+                                    </tr>
+                                    @php $computedChange = $changeDue ?? 0; @endphp
+                                    <tr class="{{ $computedChange < 0 ? 'text-danger' : 'text-success' }}">
+                                        <th>Change</th>
+                                        <th>
+                                            {{ $computedChange < 0 ? '(-)' : '(+)' }} {{ format_currency(abs($computedChange)) }}
                                         </th>
                                     </tr>
                                 </table>
@@ -104,7 +117,7 @@
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
                     <button type="submit" formaction="{{ route('app.pos.store-as-quotation') }}"
                             class="btn btn-warning">
-                        Simpan Sebagai Quotation
+                        Simpan Sebagai Dokumen Penjualan
                     </button>
                     <button type="submit" class="btn btn-primary">Submit</button>
                 </div>


### PR DESCRIPTION
## Summary
- add reactive paid amount tracking and change due computation in the Livewire POS checkout component
- show the computed change in the checkout modal, bind the paid amount input, and rename the draft button label
- reinitialize MaskMoney after Livewire updates and redirect draft saves back to the POS screen

## Testing
- php -l app/Livewire/Pos/Checkout.php
- php -l Modules/Sale/Http/Controllers/PosController.php

------
https://chatgpt.com/codex/tasks/task_e_68e4da75cd2883269042d04395fa8a8f