### PR TITLE
Add Livewire cash management workflows for POS

### DIFF
--- a/Modules/Sale/Resources/views/pos/cash-pickup.blade.php
+++ b/Modules/Sale/Resources/views/pos/cash-pickup.blade.php
@@ -1,0 +1,19 @@
+@extends('layouts.pos')
+
+@section('title', 'Penjemputan Kas')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                @include('utils.alerts')
+            </div>
+            <div class="col-12">
+                @include('sale::pos.partials.cash-navigation')
+            </div>
+            <div class="col-xl-6 col-lg-8 mx-auto">
+                <livewire:pos.cash-pickup />
+            </div>
+        </div>
+    </div>
+@endsection

--- a/Modules/Sale/Resources/views/pos/cash-reconciliation.blade.php
+++ b/Modules/Sale/Resources/views/pos/cash-reconciliation.blade.php
@@ -1,0 +1,19 @@
+@extends('layouts.pos')
+
+@section('title', 'Rekonsiliasi Kas')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                @include('utils.alerts')
+            </div>
+            <div class="col-12">
+                @include('sale::pos.partials.cash-navigation')
+            </div>
+            <div class="col-xl-6 col-lg-8 mx-auto">
+                <livewire:pos.cash-reconciliation />
+            </div>
+        </div>
+    </div>
+@endsection

--- a/Modules/Sale/Resources/views/pos/cash-settlement.blade.php
+++ b/Modules/Sale/Resources/views/pos/cash-settlement.blade.php
@@ -1,0 +1,19 @@
+@extends('layouts.pos')
+
+@section('title', 'Penyetoran Kas')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                @include('utils.alerts')
+            </div>
+            <div class="col-12">
+                @include('sale::pos.partials.cash-navigation')
+            </div>
+            <div class="col-xl-6 col-lg-8 mx-auto">
+                <livewire:pos.cash-settlement />
+            </div>
+        </div>
+    </div>
+@endsection

--- a/Modules/Sale/Resources/views/pos/index.blade.php
+++ b/Modules/Sale/Resources/views/pos/index.blade.php
@@ -19,6 +19,9 @@
             <div class="col-12">
                 @include('utils.alerts')
             </div>
+            <div class="col-12">
+                @include('sale::pos.partials.cash-navigation')
+            </div>
             <div class="col-lg-7">
                 <livewire:search-product/>
                 <livewire:pos.product-list :categories="$product_categories"/>

--- a/Modules/Sale/Resources/views/pos/partials/cash-navigation.blade.php
+++ b/Modules/Sale/Resources/views/pos/partials/cash-navigation.blade.php
@@ -1,0 +1,19 @@
+<div class="card shadow-sm mb-4">
+    <div class="card-body d-flex flex-wrap align-items-center">
+        <a href="{{ route('app.pos.cash-settlement') }}"
+           class="btn btn-outline-primary mr-2 mb-2 {{ request()->routeIs('app.pos.cash-settlement') ? 'active' : '' }}">
+            <i class="bi bi-wallet2 mr-1"></i> Penyetoran Kas
+        </a>
+        <a href="{{ route('app.pos.cash-pickup') }}"
+           class="btn btn-outline-primary mr-2 mb-2 {{ request()->routeIs('app.pos.cash-pickup') ? 'active' : '' }}">
+            <i class="bi bi-truck mr-1"></i> Penjemputan Kas
+        </a>
+        <a href="{{ route('app.pos.cash-reconciliation') }}"
+           class="btn btn-outline-primary mr-2 mb-2 {{ request()->routeIs('app.pos.cash-reconciliation') ? 'active' : '' }}">
+            <i class="bi bi-calculator mr-1"></i> Rekonsiliasi Kas
+        </a>
+        <a href="{{ route('app.pos.index') }}" class="btn btn-link mb-2 ml-auto">
+            <i class="bi bi-arrow-left mr-1"></i> Kembali ke POS
+        </a>
+    </div>
+</div>

--- a/Modules/Sale/Routes/web.php
+++ b/Modules/Sale/Routes/web.php
@@ -12,7 +12,6 @@
 */
 
 use Illuminate\Support\Facades\Route;
-use Modules\People\Entities\Customer;
 use Modules\Sale\Entities\Sale;
 use Modules\Sale\Http\Controllers\PosController;
 use Modules\Sale\Http\Controllers\SaleController;
@@ -23,6 +22,10 @@ Route::group(['middleware' => ['auth', 'role.setting']], function () {
     Route::get('/app/pos', 'PosController@index')->name('app.pos.index');
     Route::post('/app/pos', 'PosController@store')->name('app.pos.store');
     Route::post('/pos/store-as-quotation', [PosController::class, 'storeAsQuotation'])->name('app.pos.store-as-quotation');
+
+    Route::view('/app/pos/cash-settlement', 'sale::pos.cash-settlement')->name('app.pos.cash-settlement');
+    Route::view('/app/pos/cash-pickup', 'sale::pos.cash-pickup')->name('app.pos.cash-pickup');
+    Route::view('/app/pos/cash-reconciliation', 'sale::pos.cash-reconciliation')->name('app.pos.cash-reconciliation');
 
 
     //Generate PDF

--- a/app/Livewire/Pos/CashMovementComponent.php
+++ b/app/Livewire/Pos/CashMovementComponent.php
@@ -1,0 +1,253 @@
+<?php
+
+namespace App\Livewire\Pos;
+
+use App\Models\CashierCashMovement;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Component;
+use Throwable;
+
+abstract class CashMovementComponent extends Component
+{
+    /** @var array<string, int|string|null> */
+    public array $denominations = [];
+
+    /** @var array<int, string|null> */
+    public array $supportingDocuments = [];
+
+    public $manualAdjustment = null;
+
+    public $expectedTotal = null;
+
+    public string $notes = '';
+
+    public string $currencySymbol = 'Rp';
+
+    /**
+     * @var array<int, float|int>
+     */
+    protected array $denominationOptions = [100000, 50000, 20000, 10000, 5000, 2000, 1000, 500, 200, 100, 50];
+
+    public function mount(): void
+    {
+        $this->currencySymbol = $this->resolveCurrencySymbol();
+        $this->resetDenominations();
+        $this->supportingDocuments = [''];
+        $this->manualAdjustment = null;
+        $this->expectedTotal = null;
+        $this->notes = '';
+    }
+
+    public function updatedDenominations($value): void
+    {
+        if (!is_array($value)) {
+            return;
+        }
+
+        foreach ($value as $denomination => $count) {
+            $this->denominations[$denomination] = $this->sanitizeCount($count);
+        }
+    }
+
+    public function updatedManualAdjustment($value): void
+    {
+        $this->manualAdjustment = $this->sanitizeFloat($value, allowNegative: false);
+    }
+
+    public function updatedExpectedTotal($value): void
+    {
+        $this->expectedTotal = $this->sanitizeFloat($value, allowNegative: true);
+    }
+
+    public function addDocumentField(): void
+    {
+        $this->supportingDocuments[] = '';
+    }
+
+    public function removeDocumentField(int $index): void
+    {
+        if (!isset($this->supportingDocuments[$index])) {
+            return;
+        }
+
+        unset($this->supportingDocuments[$index]);
+        $this->supportingDocuments = array_values($this->supportingDocuments);
+
+        if (empty($this->supportingDocuments)) {
+            $this->supportingDocuments = [''];
+        }
+    }
+
+    public function getDenominationTotalProperty(): float
+    {
+        $total = 0.0;
+
+        foreach ($this->denominations as $value => $count) {
+            $total += ((float) $value) * $this->sanitizeCount($count);
+        }
+
+        return round($total, 2);
+    }
+
+    public function getCountedTotalProperty(): float
+    {
+        return round($this->denominationTotal + $this->sanitizeFloat($this->manualAdjustment, allowNegative: false, default: 0.0), 2);
+    }
+
+    public function getVarianceProperty(): ?float
+    {
+        $expected = $this->sanitizeFloat($this->expectedTotal, allowNegative: true, default: null);
+
+        if ($expected === null) {
+            return null;
+        }
+
+        return round($this->countedTotal - $expected, 2);
+    }
+
+    protected function sanitizeCount($value): int
+    {
+        if ($value === '' || $value === null) {
+            return 0;
+        }
+
+        if (!is_numeric($value)) {
+            return 0;
+        }
+
+        return max(0, (int) $value);
+    }
+
+    protected function sanitizeFloat($value, bool $allowNegative = false, ?float $default = 0.0): ?float
+    {
+        if ($value === null || $value === '') {
+            return $default;
+        }
+
+        if (is_string($value)) {
+            $value = str_replace(',', '.', $value);
+        }
+
+        if (!is_numeric($value)) {
+            return $default;
+        }
+
+        $numeric = (float) $value;
+
+        if (!$allowNegative) {
+            $numeric = max(0.0, $numeric);
+        }
+
+        return round($numeric, 2);
+    }
+
+    protected function resetForm(bool $resetExpected = true): void
+    {
+        $this->resetDenominations();
+        $this->supportingDocuments = [''];
+        $this->manualAdjustment = null;
+        $this->notes = '';
+
+        if ($resetExpected) {
+            $this->expectedTotal = null;
+        }
+
+        $this->resetValidation();
+        $this->resetErrorBag();
+    }
+
+    protected function resetDenominations(): void
+    {
+        $this->denominations = [];
+
+        foreach ($this->denominationOptions as $value) {
+            $this->denominations[(string) $value] = '';
+        }
+    }
+
+    protected function resolveCurrencySymbol(): string
+    {
+        try {
+            if (function_exists('settings')) {
+                $settings = settings();
+
+                if ($settings && $settings->currency && $settings->currency->symbol) {
+                    return (string) $settings->currency->symbol;
+                }
+            }
+        } catch (Throwable $exception) {
+            // Ignore and fallback
+        }
+
+        return config('app.currency_symbol', 'Rp');
+    }
+
+    protected function persistMovement(string $type, array $overrides = []): CashierCashMovement
+    {
+        $userId = Auth::id();
+
+        abort_if(!$userId, 403, 'Pengguna tidak terautentikasi.');
+
+        $cashTotal = $this->sanitizeFloat($overrides['cash_total'] ?? $this->countedTotal, allowNegative: true, default: 0.0) ?? 0.0;
+        $expectedTotal = $this->sanitizeFloat($overrides['expected_total'] ?? $this->expectedTotal, allowNegative: true, default: null);
+
+        $variance = $overrides['variance'] ?? ($expectedTotal === null ? null : round($cashTotal - $expectedTotal, 2));
+        $variance = $variance === null ? null : $this->sanitizeFloat($variance, allowNegative: true, default: null);
+
+        $denominations = $overrides['denominations'] ?? $this->prepareDenominations();
+        $documents = $overrides['documents'] ?? $this->prepareDocuments();
+        $metadata = $overrides['metadata'] ?? null;
+
+        if (is_array($metadata)) {
+            $metadata = array_filter($metadata, static fn ($value) => $value !== null && $value !== '');
+            $metadata = empty($metadata) ? null : $metadata;
+        }
+
+        return CashierCashMovement::create([
+            'user_id' => $userId,
+            'movement_type' => $type,
+            'cash_total' => round($cashTotal, 2),
+            'expected_total' => $expectedTotal === null ? null : round($expectedTotal, 2),
+            'variance' => $variance === null ? null : round($variance, 2),
+            'denominations' => $denominations,
+            'documents' => $documents,
+            'notes' => $this->notes ? trim($this->notes) : null,
+            'metadata' => $metadata,
+            'recorded_at' => now(),
+        ]);
+    }
+
+    protected function prepareDenominations(): ?array
+    {
+        $filtered = [];
+
+        foreach ($this->denominations as $value => $count) {
+            $count = $this->sanitizeCount($count);
+
+            if ($count <= 0) {
+                continue;
+            }
+
+            $filtered[$value] = $count;
+        }
+
+        return empty($filtered) ? null : $filtered;
+    }
+
+    protected function prepareDocuments(): ?array
+    {
+        $documents = [];
+
+        foreach ($this->supportingDocuments as $document) {
+            $document = $document === null ? null : trim((string) $document);
+
+            if (!$document) {
+                continue;
+            }
+
+            $documents[] = $document;
+        }
+
+        return empty($documents) ? null : $documents;
+    }
+}

--- a/app/Livewire/Pos/CashPickup.php
+++ b/app/Livewire/Pos/CashPickup.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Livewire\Pos;
+
+class CashPickup extends CashMovementComponent
+{
+    public $pickupAmount = null;
+
+    public string $recipient = '';
+
+    public string $reference = '';
+
+    protected function rules(): array
+    {
+        return [
+            'pickupAmount' => ['required', 'numeric', 'min:0.01'],
+            'denominations.*' => ['nullable', 'integer', 'min:0'],
+            'manualAdjustment' => ['nullable', 'numeric', 'min:0'],
+            'supportingDocuments.*' => ['nullable', 'string', 'max:255'],
+            'notes' => ['nullable', 'string', 'max:1000'],
+            'recipient' => ['nullable', 'string', 'max:255'],
+            'reference' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+
+    public function updatedPickupAmount($value): void
+    {
+        $this->pickupAmount = $this->sanitizeFloat($value, allowNegative: false, default: null);
+        $this->expectedTotal = $this->pickupAmount;
+    }
+
+    public function submit(): void
+    {
+        $this->validate();
+
+        $cashTotal = $this->countedTotal > 0 ? $this->countedTotal : ($this->pickupAmount ?? 0.0);
+
+        $this->persistMovement('pickup', [
+            'cash_total' => $cashTotal,
+            'expected_total' => $this->pickupAmount,
+            'metadata' => [
+                'recipient' => $this->recipient ? trim($this->recipient) : null,
+                'reference' => $this->reference ? trim($this->reference) : null,
+            ],
+        ]);
+
+        session()->flash('success', 'Penjemputan kas berhasil direkam.');
+
+        $this->resetForm();
+        $this->pickupAmount = null;
+        $this->recipient = '';
+        $this->reference = '';
+    }
+
+    public function render()
+    {
+        return view('livewire.pos.cash-pickup', [
+            'countedTotal' => $this->countedTotal,
+            'variance' => $this->variance,
+        ]);
+    }
+}

--- a/app/Livewire/Pos/CashReconciliation.php
+++ b/app/Livewire/Pos/CashReconciliation.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Livewire\Pos;
+
+class CashReconciliation extends CashMovementComponent
+{
+    public $recordedSalesTotal = null;
+
+    public $cashPickupsTotal = null;
+
+    protected function rules(): array
+    {
+        return [
+            'recordedSalesTotal' => ['required', 'numeric', 'min:0'],
+            'cashPickupsTotal' => ['nullable', 'numeric', 'min:0'],
+            'denominations.*' => ['nullable', 'integer', 'min:0'],
+            'manualAdjustment' => ['nullable', 'numeric', 'min:0'],
+            'supportingDocuments.*' => ['nullable', 'string', 'max:255'],
+            'notes' => ['nullable', 'string', 'max:1000'],
+        ];
+    }
+
+    public function updatedRecordedSalesTotal($value): void
+    {
+        $this->recordedSalesTotal = $this->sanitizeFloat($value, allowNegative: false, default: null);
+        $this->recalculateExpectedTotal();
+    }
+
+    public function updatedCashPickupsTotal($value): void
+    {
+        $this->cashPickupsTotal = $this->sanitizeFloat($value, allowNegative: false, default: null);
+        $this->recalculateExpectedTotal();
+    }
+
+    public function submit(): void
+    {
+        $this->validate();
+
+        if ($this->countedTotal <= 0) {
+            $this->addError('denominations', 'Masukkan perhitungan kas aktual.');
+            return;
+        }
+
+        $expectedOnHand = $this->expectedTotal ?? 0.0;
+
+        $this->persistMovement('reconciliation', [
+            'expected_total' => $expectedOnHand,
+            'metadata' => [
+                'recorded_sales_total' => $this->recordedSalesTotal,
+                'cash_pickups_total' => $this->cashPickupsTotal,
+            ],
+        ]);
+
+        session()->flash('success', 'Rekonsiliasi kas berhasil direkam.');
+
+        $this->resetForm();
+        $this->recordedSalesTotal = null;
+        $this->cashPickupsTotal = null;
+    }
+
+    public function render()
+    {
+        return view('livewire.pos.cash-reconciliation', [
+            'countedTotal' => $this->countedTotal,
+            'variance' => $this->variance,
+            'expectedOnHand' => $this->expectedTotal,
+        ]);
+    }
+
+    protected function recalculateExpectedTotal(): void
+    {
+        if ($this->recordedSalesTotal === null && $this->cashPickupsTotal === null) {
+            $this->expectedTotal = null;
+            return;
+        }
+
+        $sales = $this->recordedSalesTotal ?? 0.0;
+        $pickups = $this->cashPickupsTotal ?? 0.0;
+
+        $this->expectedTotal = round($sales - $pickups, 2);
+    }
+}

--- a/app/Livewire/Pos/CashSettlement.php
+++ b/app/Livewire/Pos/CashSettlement.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Livewire\Pos;
+
+class CashSettlement extends CashMovementComponent
+{
+    protected function rules(): array
+    {
+        return [
+            'expectedTotal' => ['nullable', 'numeric'],
+            'denominations.*' => ['nullable', 'integer', 'min:0'],
+            'manualAdjustment' => ['nullable', 'numeric', 'min:0'],
+            'supportingDocuments.*' => ['nullable', 'string', 'max:255'],
+            'notes' => ['nullable', 'string', 'max:1000'],
+        ];
+    }
+
+    public function submit(): void
+    {
+        $this->validate();
+
+        if ($this->countedTotal <= 0) {
+            $this->addError('denominations', 'Masukkan setidaknya satu hitungan uang tunai.');
+            return;
+        }
+
+        $this->persistMovement('settlement');
+
+        session()->flash('success', 'Penyetoran kas berhasil direkam.');
+
+        $this->resetForm();
+    }
+
+    public function render()
+    {
+        return view('livewire.pos.cash-settlement', [
+            'countedTotal' => $this->countedTotal,
+            'variance' => $this->variance,
+        ]);
+    }
+}

--- a/app/Models/CashierCashMovement.php
+++ b/app/Models/CashierCashMovement.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CashierCashMovement extends BaseModel
+{
+    use HasFactory;
+
+    protected bool $uppercaseAllText = false;
+
+    protected $fillable = [
+        'user_id',
+        'movement_type',
+        'cash_total',
+        'expected_total',
+        'variance',
+        'denominations',
+        'documents',
+        'metadata',
+        'notes',
+        'recorded_at',
+    ];
+
+    protected $casts = [
+        'cash_total' => 'decimal:2',
+        'expected_total' => 'decimal:2',
+        'variance' => 'decimal:2',
+        'denominations' => 'array',
+        'documents' => 'array',
+        'metadata' => 'array',
+        'recorded_at' => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2025_10_05_000001_create_cashier_cash_movements_table.php
+++ b/database/migrations/2025_10_05_000001_create_cashier_cash_movements_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cashier_cash_movements', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('movement_type', 50)->index();
+            $table->decimal('cash_total', 15, 2)->default(0);
+            $table->decimal('expected_total', 15, 2)->nullable();
+            $table->decimal('variance', 15, 2)->nullable();
+            $table->json('denominations')->nullable();
+            $table->json('documents')->nullable();
+            $table->json('metadata')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamp('recorded_at')->nullable()->index();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cashier_cash_movements');
+    }
+};

--- a/resources/views/layouts/header.blade.php
+++ b/resources/views/layouts/header.blade.php
@@ -13,6 +13,23 @@
                         <i class="bi bi-cart mr-1"></i> POS System
                     </a>
         </li>
+        @if(request()->routeIs('app.pos.*'))
+            <li class="c-header-nav-item mr-2">
+                <a class="btn btn-outline-light btn-pill {{ request()->routeIs('app.pos.cash-settlement') ? 'active' : '' }}" href="{{ route('app.pos.cash-settlement') }}">
+                    <i class="bi bi-wallet2 mr-1"></i> Penyetoran
+                </a>
+            </li>
+            <li class="c-header-nav-item mr-2">
+                <a class="btn btn-outline-light btn-pill {{ request()->routeIs('app.pos.cash-pickup') ? 'active' : '' }}" href="{{ route('app.pos.cash-pickup') }}">
+                    <i class="bi bi-truck mr-1"></i> Penjemputan
+                </a>
+            </li>
+            <li class="c-header-nav-item mr-3">
+                <a class="btn btn-outline-light btn-pill {{ request()->routeIs('app.pos.cash-reconciliation') ? 'active' : '' }}" href="{{ route('app.pos.cash-reconciliation') }}">
+                    <i class="bi bi-calculator mr-1"></i> Rekonsiliasi
+                </a>
+            </li>
+        @endif
     @endcan
 
     @if(session('user_settings'))

--- a/resources/views/livewire/pos/cash-pickup.blade.php
+++ b/resources/views/livewire/pos/cash-pickup.blade.php
@@ -1,0 +1,81 @@
+<div>
+    <div class="card shadow-sm">
+        <div class="card-header bg-white">
+            <h5 class="mb-0">Penjemputan Kas</h5>
+        </div>
+        <div class="card-body">
+            @if (session()->has('success'))
+                <div class="alert alert-success">{{ session('success') }}</div>
+            @endif
+
+            <form wire:submit.prevent="submit">
+                <div class="form-row">
+                    <div class="form-group col-md-6">
+                        <label for="pickup-amount">Nominal Penjemputan</label>
+                        <div class="input-group">
+                            <div class="input-group-prepend">
+                                <span class="input-group-text">{{ $currencySymbol }}</span>
+                            </div>
+                            <input type="number" step="0.01" min="0" id="pickup-amount" class="form-control"
+                                   wire:model.lazy="pickupAmount" placeholder="0.00">
+                        </div>
+                        @error('pickupAmount')
+                            <span class="text-danger small">{{ $message }}</span>
+                        @enderror
+                    </div>
+                    <div class="form-group col-md-6">
+                        <label for="recipient">Petugas / Penerima</label>
+                        <input type="text" id="recipient" class="form-control" wire:model.lazy="recipient"
+                               placeholder="Nama petugas penjemput">
+                        @error('recipient')
+                            <span class="text-danger small">{{ $message }}</span>
+                        @enderror
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label for="reference">Referensi / Dokumen</label>
+                    <input type="text" id="reference" class="form-control" wire:model.lazy="reference"
+                           placeholder="Contoh: Nomor berita acara">
+                    @error('reference')
+                        <span class="text-danger small">{{ $message }}</span>
+                    @enderror
+                </div>
+
+                @include('livewire.pos.partials.denomination-table', [
+                    'denominations' => $denominations,
+                    'currencySymbol' => $currencySymbol,
+                    'countedTotal' => $countedTotal,
+                    'expectedTotal' => $pickupAmount,
+                    'variance' => $variance,
+                ])
+
+                <div class="form-group">
+                    <label>Dokumen Pendukung</label>
+                    @foreach($supportingDocuments as $index => $document)
+                        <div class="input-group mb-2" wire:key="pickup-document-{{ $index }}">
+                            <input type="text" class="form-control" placeholder="Contoh: Foto tas uang"
+                                   wire:model.lazy="supportingDocuments.{{ $index }}">
+                            <div class="input-group-append">
+                                <button type="button" class="btn btn-outline-danger"
+                                        wire:click="removeDocumentField({{ $index }})"
+                                        {{ count($supportingDocuments) === 1 ? 'disabled' : '' }}>
+                                    <i class="bi bi-x"></i>
+                                </button>
+                            </div>
+                        </div>
+                    @endforeach
+                    <button type="button" class="btn btn-link p-0" wire:click="addDocumentField">+ Tambah dokumen</button>
+                </div>
+
+                <div class="form-group">
+                    <label for="pickup-notes">Catatan</label>
+                    <textarea id="pickup-notes" rows="3" class="form-control" wire:model.lazy="notes"
+                              placeholder="Catat tujuan atau detail penjemputan"></textarea>
+                </div>
+
+                <button type="submit" class="btn btn-primary btn-block">Simpan Penjemputan Kas</button>
+            </form>
+        </div>
+    </div>
+</div>

--- a/resources/views/livewire/pos/cash-reconciliation.blade.php
+++ b/resources/views/livewire/pos/cash-reconciliation.blade.php
@@ -1,0 +1,87 @@
+<div>
+    <div class="card shadow-sm">
+        <div class="card-header bg-white">
+            <h5 class="mb-0">Rekonsiliasi Kas</h5>
+        </div>
+        <div class="card-body">
+            @if (session()->has('success'))
+                <div class="alert alert-success">{{ session('success') }}</div>
+            @endif
+
+            <form wire:submit.prevent="submit">
+                <div class="form-row">
+                    <div class="form-group col-md-6">
+                        <label for="recorded-sales">Penjualan Tercatat</label>
+                        <div class="input-group">
+                            <div class="input-group-prepend">
+                                <span class="input-group-text">{{ $currencySymbol }}</span>
+                            </div>
+                            <input type="number" step="0.01" min="0" id="recorded-sales" class="form-control"
+                                   wire:model.lazy="recordedSalesTotal" placeholder="0.00">
+                        </div>
+                        @error('recordedSalesTotal')
+                            <span class="text-danger small">{{ $message }}</span>
+                        @enderror
+                    </div>
+                    <div class="form-group col-md-6">
+                        <label for="cash-pickups">Total Penjemputan Kas</label>
+                        <div class="input-group">
+                            <div class="input-group-prepend">
+                                <span class="input-group-text">{{ $currencySymbol }}</span>
+                            </div>
+                            <input type="number" step="0.01" min="0" id="cash-pickups" class="form-control"
+                                   wire:model.lazy="cashPickupsTotal" placeholder="0.00">
+                        </div>
+                        <small class="form-text text-muted">Masukkan total kas yang sudah diambil dari laci.</small>
+                        @error('cashPickupsTotal')
+                            <span class="text-danger small d-block">{{ $message }}</span>
+                        @enderror
+                    </div>
+                </div>
+
+                <div class="alert alert-info">
+                    <strong>Kas yang seharusnya ada:</strong>
+                    {{ $currencySymbol }} {{ number_format($expectedOnHand ?? 0, 2, ',', '.') }}
+                </div>
+
+                @include('livewire.pos.partials.denomination-table', [
+                    'denominations' => $denominations,
+                    'currencySymbol' => $currencySymbol,
+                    'countedTotal' => $countedTotal,
+                    'expectedOnHand' => $expectedOnHand,
+                    'variance' => $variance,
+                ])
+
+                @error('denominations')
+                    <div class="text-danger small mb-2">{{ $message }}</div>
+                @enderror
+
+                <div class="form-group">
+                    <label>Dokumen Pendukung</label>
+                    @foreach($supportingDocuments as $index => $document)
+                        <div class="input-group mb-2" wire:key="recon-document-{{ $index }}">
+                            <input type="text" class="form-control" placeholder="Contoh: Foto kas akhir"
+                                   wire:model.lazy="supportingDocuments.{{ $index }}">
+                            <div class="input-group-append">
+                                <button type="button" class="btn btn-outline-danger"
+                                        wire:click="removeDocumentField({{ $index }})"
+                                        {{ count($supportingDocuments) === 1 ? 'disabled' : '' }}>
+                                    <i class="bi bi-x"></i>
+                                </button>
+                            </div>
+                        </div>
+                    @endforeach
+                    <button type="button" class="btn btn-link p-0" wire:click="addDocumentField">+ Tambah dokumen</button>
+                </div>
+
+                <div class="form-group">
+                    <label for="recon-notes">Catatan</label>
+                    <textarea id="recon-notes" rows="3" class="form-control" wire:model.lazy="notes"
+                              placeholder="Catat temuan atau tindak lanjut"></textarea>
+                </div>
+
+                <button type="submit" class="btn btn-primary btn-block">Simpan Rekonsiliasi</button>
+            </form>
+        </div>
+    </div>
+</div>

--- a/resources/views/livewire/pos/cash-settlement.blade.php
+++ b/resources/views/livewire/pos/cash-settlement.blade.php
@@ -1,0 +1,67 @@
+<div>
+    <div class="card shadow-sm">
+        <div class="card-header bg-white">
+            <h5 class="mb-0">Penyetoran Kas</h5>
+        </div>
+        <div class="card-body">
+            @if (session()->has('success'))
+                <div class="alert alert-success">{{ session('success') }}</div>
+            @endif
+
+            <form wire:submit.prevent="submit">
+                <div class="form-group">
+                    <label for="expected-total">Total Penjualan Tercatat</label>
+                    <div class="input-group">
+                        <div class="input-group-prepend">
+                            <span class="input-group-text">{{ $currencySymbol }}</span>
+                        </div>
+                        <input type="number" step="0.01" min="0" id="expected-total" class="form-control"
+                               placeholder="0.00" wire:model.lazy="expectedTotal">
+                    </div>
+                    <small class="form-text text-muted">Masukkan total penjualan menurut sistem untuk sesi ini.</small>
+                    @error('expectedTotal')
+                        <span class="text-danger small">{{ $message }}</span>
+                    @enderror
+                </div>
+
+                @include('livewire.pos.partials.denomination-table', [
+                    'denominations' => $denominations,
+                    'currencySymbol' => $currencySymbol,
+                    'countedTotal' => $countedTotal,
+                    'expectedTotal' => $expectedTotal,
+                    'variance' => $variance,
+                ])
+
+                @error('denominations')
+                    <div class="text-danger small mb-2">{{ $message }}</div>
+                @enderror
+
+                <div class="form-group">
+                    <label>Dokumen Pendukung</label>
+                    @foreach($supportingDocuments as $index => $document)
+                        <div class="input-group mb-2" wire:key="document-{{ $index }}">
+                            <input type="text" class="form-control" placeholder="Contoh: Slip setoran bank"
+                                   wire:model.lazy="supportingDocuments.{{ $index }}">
+                            <div class="input-group-append">
+                                <button type="button" class="btn btn-outline-danger"
+                                        wire:click="removeDocumentField({{ $index }})"
+                                        {{ count($supportingDocuments) === 1 ? 'disabled' : '' }}>
+                                    <i class="bi bi-x"></i>
+                                </button>
+                            </div>
+                        </div>
+                    @endforeach
+                    <button type="button" class="btn btn-link p-0" wire:click="addDocumentField">+ Tambah dokumen</button>
+                </div>
+
+                <div class="form-group">
+                    <label for="notes">Catatan Tambahan</label>
+                    <textarea id="notes" rows="3" class="form-control" wire:model.lazy="notes"
+                              placeholder="Catat detail penting lainnya"></textarea>
+                </div>
+
+                <button type="submit" class="btn btn-primary btn-block">Simpan Penyetoran Kas</button>
+            </form>
+        </div>
+    </div>
+</div>

--- a/resources/views/livewire/pos/partials/denomination-table.blade.php
+++ b/resources/views/livewire/pos/partials/denomination-table.blade.php
@@ -1,0 +1,64 @@
+<div class="table-responsive mb-3">
+    <table class="table table-sm table-striped">
+        <thead>
+        <tr>
+            <th class="text-uppercase small text-muted">Nominal</th>
+            <th class="text-uppercase small text-muted">Jumlah Lembar/Koin</th>
+            <th class="text-uppercase small text-muted text-right">Total</th>
+        </tr>
+        </thead>
+        <tbody>
+        @foreach($denominations as $value => $count)
+            @php
+                $pieces = is_numeric($count) ? (int) $count : 0;
+                $lineTotal = $pieces * (float) $value;
+            @endphp
+            <tr>
+                <td class="align-middle">{{ $currencySymbol }} {{ number_format((float) $value, 0, ',', '.') }}</td>
+                <td>
+                    <input type="number" min="0" step="1" class="form-control form-control-sm"
+                           wire:model.lazy="denominations.{{ $value }}">
+                </td>
+                <td class="text-right align-middle">{{ $currencySymbol }} {{ number_format($lineTotal, 0, ',', '.') }}</td>
+            </tr>
+        @endforeach
+        <tr>
+            <td class="align-middle">Kas Lainnya / Pembulatan</td>
+            <td colspan="2">
+                <div class="input-group input-group-sm">
+                    <div class="input-group-prepend">
+                        <span class="input-group-text">{{ $currencySymbol }}</span>
+                    </div>
+                    <input type="number" step="0.01" min="0" class="form-control" wire:model.lazy="manualAdjustment">
+                </div>
+                <small class="form-text text-muted">Gunakan kolom ini untuk koin atau penyesuaian kecil lainnya.</small>
+            </td>
+        </tr>
+        </tbody>
+        <tfoot>
+        <tr>
+            <th colspan="2" class="text-right">Total Fisik</th>
+            <th class="text-right">{{ $currencySymbol }} {{ number_format($countedTotal, 2, ',', '.') }}</th>
+        </tr>
+        @if(isset($expectedOnHand))
+            <tr>
+                <th colspan="2" class="text-right">Perkiraan Seharusnya</th>
+                <th class="text-right">{{ $currencySymbol }} {{ number_format($expectedOnHand ?? 0, 2, ',', '.') }}</th>
+            </tr>
+        @elseif(isset($expectedTotal))
+            <tr>
+                <th colspan="2" class="text-right">Total yang Diharapkan</th>
+                <th class="text-right">{{ $currencySymbol }} {{ number_format($expectedTotal ?? 0, 2, ',', '.') }}</th>
+            </tr>
+        @endif
+        @if(isset($variance))
+            <tr>
+                <th colspan="2" class="text-right">Selisih</th>
+                <th class="text-right {{ ($variance ?? 0) === 0.0 ? 'text-success' : 'text-danger' }}">
+                    {{ $currencySymbol }} {{ number_format($variance ?? 0, 2, ',', '.') }}
+                </th>
+            </tr>
+        @endif
+        </tfoot>
+    </table>
+</div>


### PR DESCRIPTION
## Summary
- add Livewire components and pages for cash settlement, cash pickup, and cash reconciliation in the POS module
- surface navigation shortcuts in the POS header and layout to reach the new cash management workflows
- persist cashier cash movements with a dedicated model and migration for tracking totals, variances, and supporting documents

## Testing
- php artisan test *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68e4deed4bac8326aed4d95c2171b2d4