### PR TITLE
Update POS checkout event dispatch for Livewire 3

### DIFF
--- a/app/Livewire/Pos/Checkout.php
+++ b/app/Livewire/Pos/Checkout.php
@@ -78,7 +78,7 @@ class Checkout extends Component
     public function hydrate()
     {
         $this->refreshTotals();
-        $this->dispatchBrowserEvent('pos-mask-money-init');
+        $this->dispatch('pos-mask-money-init');
     }
 
     public function updatedPaidAmount($value): void
@@ -127,7 +127,7 @@ class Checkout extends Component
     {
         Cart::instance($this->cart_instance)->destroy();
         $this->refreshTotals(true);
-        $this->dispatchBrowserEvent('pos-mask-money-init');
+        $this->dispatch('pos-mask-money-init');
     }
 
     public function productSelected($product)


### PR DESCRIPTION
## Summary
- replace legacy `dispatchBrowserEvent` calls in the POS checkout component with Livewire 3's `dispatch` helper to fire the `pos-mask-money-init` window event
- verified the POS index view continues to listen for the `pos-mask-money-init` window event so currency masking still initializes after hydration and cart resets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e50189c5a483269f2cc7c0cff71415