### PR TITLE
Fix mismatched placeholders in POS serial lookup query

### DIFF
--- a/app/Livewire/SearchProduct.php
+++ b/app/Livewire/SearchProduct.php
@@ -103,18 +103,19 @@ class SearchProduct extends Component
             SELECT product_id,
                    SUM((quantity_non_tax + quantity_tax) - (broken_quantity_non_tax + broken_quantity_tax)) AS stock_qty
             FROM product_stocks
-            WHERE (location_id = COALESCE(:posLocationId1, location_id))
+            WHERE (location_id = COALESCE(:stockLocationId, location_id))
             GROUP BY product_id
         ) st ON st.product_id = p.id
         WHERE LOWER(psn.serial_number) = LOWER(:code)
           AND psn.is_broken = 0
-          AND (psn.location_id = COALESCE(:posLocationId1, psn.location_id))
+          AND (psn.location_id = COALESCE(:serialLocationId, psn.location_id))
         LIMIT 1
     ";
 
         $row = DB::selectOne($sql, [
-            'code'            => $code,
-            'posLocationId1'  => $this->posLocationId,
+            'code'              => $code,
+            'stockLocationId'   => $this->posLocationId,
+            'serialLocationId'  => $this->posLocationId,
         ]);
 
         if (!$row) return false;


### PR DESCRIPTION
## Summary
- rename the stock and serial location placeholders in the exact serial scan query to use distinct parameter names
- bind the new placeholder names in the selectOne call so the POS location is still applied

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5041568088326a20cc5c6ef2d32bc