### PR TITLE
Introduce per-setting product unit conversion pricing

### DIFF
--- a/Modules/Product/Database/Migrations/2025_09_10_120000_create_product_unit_conversion_prices_table.php
+++ b/Modules/Product/Database/Migrations/2025_09_10_120000_create_product_unit_conversion_prices_table.php
@@ -1,0 +1,89 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('product_unit_conversion_prices', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('product_unit_conversion_id')
+                ->constrained('product_unit_conversions')
+                ->cascadeOnDelete();
+            $table->foreignId('setting_id')
+                ->constrained('settings')
+                ->cascadeOnDelete();
+            $table->decimal('price', 15, 2)->default(0);
+            $table->timestamps();
+
+            $table->unique(['product_unit_conversion_id', 'setting_id'], 'conversion_setting_unique');
+        });
+
+        $settingIds = DB::table('settings')->pluck('id')->all();
+        if (empty($settingIds)) {
+            $settingIds = DB::table('products')
+                ->distinct()
+                ->whereNotNull('setting_id')
+                ->pluck('setting_id')
+                ->all();
+        }
+
+        if (!empty($settingIds)) {
+            DB::table('product_unit_conversions')
+                ->select(['id', 'price'])
+                ->orderBy('id')
+                ->chunkById(500, function ($conversions) use ($settingIds) {
+                    $timestamp = now();
+                    $rows = [];
+
+                    foreach ($conversions as $conversion) {
+                        foreach ($settingIds as $settingId) {
+                            $rows[] = [
+                                'product_unit_conversion_id' => $conversion->id,
+                                'setting_id'                 => (int) $settingId,
+                                'price'                      => $conversion->price ?? 0,
+                                'created_at'                 => $timestamp,
+                                'updated_at'                 => $timestamp,
+                            ];
+                        }
+                    }
+
+                    if (!empty($rows)) {
+                        DB::table('product_unit_conversion_prices')->insert($rows);
+                    }
+                });
+        }
+
+        Schema::table('product_unit_conversions', function (Blueprint $table) {
+            if (Schema::hasColumn('product_unit_conversions', 'price')) {
+                $table->dropColumn('price');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('product_unit_conversions', function (Blueprint $table) {
+            if (!Schema::hasColumn('product_unit_conversions', 'price')) {
+                $table->decimal('price', 15, 2)->default(0)->after('conversion_factor');
+            }
+        });
+
+        $priceRows = DB::table('product_unit_conversion_prices')
+            ->select('product_unit_conversion_id', DB::raw('MAX(price) as price'))
+            ->groupBy('product_unit_conversion_id')
+            ->get();
+
+        foreach ($priceRows as $row) {
+            DB::table('product_unit_conversions')
+                ->where('id', $row->product_unit_conversion_id)
+                ->update(['price' => $row->price ?? 0]);
+        }
+
+        Schema::dropIfExists('product_unit_conversion_prices');
+    }
+};

--- a/Modules/Product/Entities/ProductUnitConversion.php
+++ b/Modules/Product/Entities/ProductUnitConversion.php
@@ -4,11 +4,15 @@ namespace Modules\Product\Entities;
 
 use App\Models\BaseModel;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Modules\Setting\Entities\Unit;
 
+/**
+ * @property-read \Illuminate\Support\Collection<int, ProductUnitConversionPrice> $prices
+ */
 class ProductUnitConversion extends BaseModel
 {
-    protected $fillable = ['product_id', 'unit_id', 'base_unit_id', 'conversion_factor', 'barcode', 'price'];
+    protected $fillable = ['product_id', 'unit_id', 'base_unit_id', 'conversion_factor', 'barcode'];
 
     public function product(): BelongsTo
     {
@@ -23,5 +27,24 @@ class ProductUnitConversion extends BaseModel
     public function baseUnit(): BelongsTo
     {
         return $this->belongsTo(Unit::class, 'base_unit_id');
+    }
+
+    public function prices(): HasMany
+    {
+        return $this->hasMany(ProductUnitConversionPrice::class, 'product_unit_conversion_id');
+    }
+
+    public function priceForSetting(int $settingId): ?ProductUnitConversionPrice
+    {
+        if ($this->relationLoaded('prices')) {
+            return $this->prices->firstWhere('setting_id', $settingId);
+        }
+
+        return $this->prices()->where('setting_id', $settingId)->first();
+    }
+
+    public function priceValueForSetting(int $settingId): float
+    {
+        return (float) optional($this->priceForSetting($settingId))->price ?? 0.0;
     }
 }

--- a/Modules/Product/Entities/ProductUnitConversionPrice.php
+++ b/Modules/Product/Entities/ProductUnitConversionPrice.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Modules\Product\Entities;
+
+use App\Models\BaseModel;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Modules\Setting\Entities\Setting;
+use Modules\Product\Entities\ProductUnitConversion;
+
+/**
+ * @method static Builder|ProductUnitConversionPrice forConversion(int $conversionId)
+ * @method static Builder|ProductUnitConversionPrice forSetting(int $settingId)
+ */
+class ProductUnitConversionPrice extends BaseModel
+{
+    protected $table = 'product_unit_conversion_prices';
+
+    protected $fillable = [
+        'product_unit_conversion_id',
+        'setting_id',
+        'price',
+    ];
+
+    protected $casts = [
+        'price' => 'decimal:2',
+    ];
+
+    public function conversion(): BelongsTo
+    {
+        return $this->belongsTo(ProductUnitConversion::class, 'product_unit_conversion_id');
+    }
+
+    public function setting(): BelongsTo
+    {
+        return $this->belongsTo(Setting::class, 'setting_id');
+    }
+
+    public function scopeForConversion(Builder $query, int $conversionId): Builder
+    {
+        return $query->where('product_unit_conversion_id', $conversionId);
+    }
+
+    public function scopeForSetting(Builder $query, int $settingId): Builder
+    {
+        return $query->where('setting_id', $settingId);
+    }
+
+    public static function upsertFor(array $attributes): self
+    {
+        return static::updateOrCreate(
+            [
+                'product_unit_conversion_id' => $attributes['product_unit_conversion_id'],
+                'setting_id'                 => $attributes['setting_id'],
+            ],
+            $attributes
+        );
+    }
+
+    /**
+     * @param iterable<int> $settingIds
+     */
+    public static function seedForSettings(int $conversionId, float $price, iterable $settingIds): void
+    {
+        foreach ($settingIds as $settingId) {
+            static::upsertFor([
+                'product_unit_conversion_id' => $conversionId,
+                'setting_id'                 => (int) $settingId,
+                'price'                      => $price,
+            ]);
+        }
+    }
+}

--- a/Modules/Product/Resources/views/products/edit.blade.php
+++ b/Modules/Product/Resources/views/products/edit.blade.php
@@ -206,7 +206,7 @@
                                         <div class="card">
                                             <div class="card-body">
                                                 <livewire:product.unit-conversion-table
-                                                    :conversions="old('conversions', $product->conversions->toArray())"
+                                                    :conversions="old('conversions', $conversionFormData)"
                                                     :errors="$errors->toArray()"/>
                                             </div>
                                         </div>

--- a/app/Livewire/PricePoint/Browser.php
+++ b/app/Livewire/PricePoint/Browser.php
@@ -51,6 +51,8 @@ class Browser extends Component
     {
         $term = trim($this->q);
 
+        $settingId = $this->setting->id;
+
         $products = Product::query()
             ->select('products.*')
             ->selectSub(function ($q) {
@@ -83,7 +85,12 @@ class Browser extends Component
             ->with([
                 'brand:id,name',
                 'category:id,category_name',
-                'conversions.unit:id,name',
+                'conversions' => function ($q) use ($settingId) {
+                    $q->with([
+                        'unit:id,name',
+                        'prices' => fn ($priceQuery) => $priceQuery->where('setting_id', $settingId),
+                    ]);
+                },
             ])
             ->when($term !== '', function ($q) use ($term) {
                 $like = "%{$term}%";

--- a/resources/views/livewire/price-point/browser.blade.php
+++ b/resources/views/livewire/price-point/browser.blade.php
@@ -174,7 +174,10 @@
                                                         <span class="inline-flex items-center rounded border border-slate-200 bg-white px-2 py-0.5 text-[13px] md:text-[12px] text-slate-700">
                                                             {{ $uc->unit->short_name ?? $uc->unit->name ?? 'Unit' }}
                                                             @if($uc->quantity) x{{ (int)$uc->quantity }} @endif
-                                                            @if(!is_null($uc->price)) • {{ number_format((float)$uc->price, 0, ',', '.') }} @endif
+                                                            @php($conversionPrice = $uc->priceForSetting($setting->id))
+                                                            @if($conversionPrice)
+                                                                • {{ number_format((float) $conversionPrice->price, 0, ',', '.') }}
+                                                            @endif
                                                             @if($uc->barcode) • <span class="font-mono break-all">{{ $uc->barcode }}</span> @endif
                                                         </span>
                                                     @endforeach

--- a/tests/Feature/ProductUnitConversionPriceTest.php
+++ b/tests/Feature/ProductUnitConversionPriceTest.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\CheckUserRoleForSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Modules\Currency\Entities\Currency;
+use Modules\Product\Entities\Product;
+use Modules\Product\Entities\ProductUnitConversion;
+use Modules\Product\Entities\ProductUnitConversionPrice;
+use Modules\Setting\Entities\Setting;
+use Modules\Setting\Entities\Unit;
+use Tests\TestCase;
+
+class ProductUnitConversionPriceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedSettings(): array
+    {
+        $currency = Currency::create([
+            'currency_name'       => 'Rupiah',
+            'code'                => 'IDR',
+            'symbol'              => 'Rp',
+            'thousand_separator'  => '.',
+            'decimal_separator'   => ',',
+            'exchange_rate'       => 1,
+        ]);
+
+        $primary = Setting::create([
+            'company_name'              => 'Alpha Co',
+            'company_email'             => 'alpha@example.com',
+            'company_phone'             => '11111',
+            'site_logo'                 => null,
+            'default_currency_id'       => $currency->id,
+            'default_currency_position' => 'left',
+            'notification_email'        => 'notify-alpha@example.com',
+            'footer_text'               => 'Alpha',
+            'company_address'           => 'Alpha Street',
+        ]);
+
+        $secondary = Setting::create([
+            'company_name'              => 'Beta Co',
+            'company_email'             => 'beta@example.com',
+            'company_phone'             => '22222',
+            'site_logo'                 => null,
+            'default_currency_id'       => $currency->id,
+            'default_currency_position' => 'left',
+            'notification_email'        => 'notify-beta@example.com',
+            'footer_text'               => 'Beta',
+            'company_address'           => 'Beta Street',
+        ]);
+
+        return [$primary, $secondary];
+    }
+
+    private function createUnit(Setting $setting, string $name): Unit
+    {
+        return Unit::create([
+            'name'       => $name,
+            'short_name' => substr($name, 0, 3),
+            'operator'   => null,
+            'operation_value' => null,
+            'setting_id' => $setting->id,
+        ]);
+    }
+
+    public function test_product_store_creates_conversion_prices_for_all_settings(): void
+    {
+        Gate::shouldReceive('denies')->with('products.create')->andReturnFalse();
+        Gate::shouldReceive('allows')->with('products.create')->andReturnTrue();
+
+        [$primarySetting, $secondarySetting] = $this->seedSettings();
+
+        $user = User::factory()->create();
+        $this->actingAs($user);
+        $this->withoutMiddleware([CheckUserRoleForSetting::class]);
+
+        $baseUnit       = $this->createUnit($primarySetting, 'Piece');
+        $conversionUnit = $this->createUnit($primarySetting, 'Box');
+
+        $payload = [
+            'product_name'   => 'Conversion Product',
+            'product_code'   => 'CONV-001',
+            'stock_managed'  => true,
+            'base_unit_id'   => $baseUnit->id,
+            'conversions'    => [
+                [
+                    'unit_id'           => $conversionUnit->id,
+                    'conversion_factor' => 2,
+                    'price'             => 9900,
+                    'barcode'           => 'BOX-9900',
+                ],
+            ],
+            'is_purchased'   => false,
+            'is_sold'        => false,
+        ];
+
+        $response = $this->withSession(['setting_id' => $primarySetting->id])
+            ->post(route('products.store'), $payload);
+
+        $response->assertRedirect(route('products.index'));
+
+        $conversion = ProductUnitConversion::first();
+        $this->assertNotNull($conversion);
+
+        $prices = ProductUnitConversionPrice::where('product_unit_conversion_id', $conversion->id)
+            ->pluck('price', 'setting_id')
+            ->map(fn ($value) => (float) $value)
+            ->all();
+
+        $this->assertCount(2, $prices);
+        $this->assertSame(9900.0, $prices[$primarySetting->id]);
+        $this->assertSame(9900.0, $prices[$secondarySetting->id]);
+    }
+
+    public function test_product_update_updates_only_active_setting_conversion_price(): void
+    {
+        Gate::shouldReceive('denies')->with('products.edit')->andReturnFalse();
+        Gate::shouldReceive('allows')->with('products.edit')->andReturnTrue();
+
+        [$primarySetting, $secondarySetting] = $this->seedSettings();
+
+        $user = User::factory()->create();
+        $this->actingAs($user);
+        $this->withoutMiddleware([CheckUserRoleForSetting::class]);
+
+        $baseUnit       = $this->createUnit($primarySetting, 'Piece');
+        $conversionUnit = $this->createUnit($primarySetting, 'Pack');
+
+        $product = Product::create([
+            'product_name'       => 'Existing Product',
+            'product_code'       => 'EXIST-001',
+            'base_unit_id'       => $baseUnit->id,
+            'unit_id'            => $baseUnit->id,
+            'stock_managed'      => 1,
+            'is_purchased'       => 0,
+            'is_sold'            => 0,
+            'setting_id'         => $primarySetting->id,
+        ]);
+
+        $conversion = ProductUnitConversion::create([
+            'product_id'        => $product->id,
+            'unit_id'           => $conversionUnit->id,
+            'base_unit_id'      => $baseUnit->id,
+            'conversion_factor' => 3,
+            'barcode'           => 'PACK-OLD',
+        ]);
+
+        ProductUnitConversionPrice::upsertFor([
+            'product_unit_conversion_id' => $conversion->id,
+            'setting_id'                 => $primarySetting->id,
+            'price'                      => 15000,
+        ]);
+        ProductUnitConversionPrice::upsertFor([
+            'product_unit_conversion_id' => $conversion->id,
+            'setting_id'                 => $secondarySetting->id,
+            'price'                      => 21000,
+        ]);
+
+        $payload = [
+            'product_name'  => 'Existing Product',
+            'product_code'  => 'EXIST-001',
+            'stock_managed' => true,
+            'base_unit_id'  => $baseUnit->id,
+            'conversions'   => [
+                [
+                    'id'                => $conversion->id,
+                    'unit_id'           => $conversionUnit->id,
+                    'conversion_factor' => 3,
+                    'price'             => 17500,
+                    'barcode'           => 'PACK-OLD',
+                ],
+            ],
+            'is_purchased'  => false,
+            'is_sold'       => false,
+        ];
+
+        $response = $this->withSession(['setting_id' => $primarySetting->id])
+            ->put(route('products.update', $product), $payload);
+
+        $response->assertRedirect(route('products.index'));
+
+        $this->assertSame(17500.0, (float) ProductUnitConversionPrice::where([
+            'product_unit_conversion_id' => $conversion->id,
+            'setting_id'                 => $primarySetting->id,
+        ])->value('price'));
+
+        $this->assertSame(21000.0, (float) ProductUnitConversionPrice::where([
+            'product_unit_conversion_id' => $conversion->id,
+            'setting_id'                 => $secondarySetting->id,
+        ])->value('price'));
+    }
+}


### PR DESCRIPTION
## Summary
- add a migration that moves unit conversion prices into a dedicated per-setting table and removes the legacy column
- update ProductUnitConversion, controllers, import jobs, and price point views to read/write conversion prices per setting
- cover multi-setting conversion price creation and updates with new feature tests

## Testing
- php artisan test tests/Feature/ProductUnitConversionPriceTest.php *(fails: dependencies require PHP <= 8.3 so composer install cannot complete)*

------
https://chatgpt.com/codex/tasks/task_e_68fc9e7419248326ad0c48a81d9ff698