### PR TITLE
Remove POS flag inputs from location management

### DIFF
--- a/Modules/Setting/Http/Controllers/LocationController.php
+++ b/Modules/Setting/Http/Controllers/LocationController.php
@@ -11,7 +11,6 @@ use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Gate;
 use Modules\Product\Entities\ProductStock;
 use Modules\Setting\Entities\Location;
-use Modules\Setting\Entities\SettingSaleLocation;
 
 class LocationController extends Controller
 {
@@ -48,32 +47,15 @@ class LocationController extends Controller
         abort_if(Gate::denies('locations.create'), 403);
 
         $request->validate([
-            'name'   => 'required|string|max:255',
-            'is_pos' => 'nullable|boolean',
+            'name' => 'required|string|max:255',
         ]);
 
         $settingId = session('setting_id');
-        $isPos     = $request->boolean('is_pos');
-
-        if ($isPos) {
-            $exists = SettingSaleLocation::query()
-                ->where('setting_id', $settingId)
-                ->where('is_pos', true)
-                ->exists();
-
-            if ($exists) {
-                return back()
-                    ->withErrors(['is_pos' => 'Hanya boleh ada satu lokasi POS untuk setiap bisnis/setting.'])
-                    ->withInput();
-            }
-        }
 
         $location = Location::create([
             'name'       => $request->name,
             'setting_id' => $settingId,
         ]);
-
-        $location->saleAssignment()->update(['is_pos' => $isPos]);
 
         toast('Lokasi Berhasil ditambahkan!', 'success');
 
@@ -99,31 +81,12 @@ class LocationController extends Controller
         abort_if(Gate::denies('locations.edit'), 403);
 
         $request->validate([
-            'name'   => 'required|string|max:255',
-            'is_pos' => 'nullable|boolean',
+            'name' => 'required|string|max:255',
         ]);
-
-        $isPos = $request->boolean('is_pos');
-
-        if ($isPos) {
-            $exists = SettingSaleLocation::query()
-                ->where('setting_id', $location->setting_id)
-                ->where('is_pos', true)
-                ->where('location_id', '!=', $location->id)
-                ->exists();
-
-            if ($exists) {
-                return back()
-                    ->withErrors(['is_pos' => 'Hanya boleh ada satu lokasi POS untuk setiap bisnis/setting.'])
-                    ->withInput();
-            }
-        }
 
         $location->update([
             'name' => $request->name,
         ]);
-
-        $location->saleAssignment()->update(['is_pos' => $isPos]);
 
         toast('Lokasi diperbaharui!', 'info');
 

--- a/Modules/Setting/Resources/views/locations/create.blade.php
+++ b/Modules/Setting/Resources/views/locations/create.blade.php
@@ -41,23 +41,6 @@
                                         @enderror
                                     </div>
 
-                                    {{-- is_pos --}}
-                                    <div class="form-group form-check mt-2">
-                                        <input
-                                            type="checkbox"
-                                            class="form-check-input @error('is_pos') is-invalid @enderror"
-                                            id="is_pos"
-                                            name="is_pos"
-                                            value="1"
-                                            {{ old('is_pos') ? 'checked' : '' }}
-                                        >
-                                        <label class="form-check-label" for="is_pos">
-                                            Gunakan lokasi ini untuk POS
-                                        </label>
-                                        @error('is_pos')
-                                        <div class="invalid-feedback d-block">{{ $message }}</div>
-                                        @enderror
-                                    </div>
                                 </div>
 
                                 <div class="col-lg-12 d-flex justify-content-end">

--- a/Modules/Setting/Resources/views/locations/edit.blade.php
+++ b/Modules/Setting/Resources/views/locations/edit.blade.php
@@ -42,27 +42,6 @@
                                         @enderror
                                     </div>
 
-                                    {{-- ensure a value is always sent --}}
-                                    <input type="hidden" name="is_pos" value="0">
-
-                                    {{-- is_pos checkbox --}}
-                                    <div class="form-group form-check mt-2">
-                                        <input
-                                            type="checkbox"
-                                            class="form-check-input @error('is_pos') is-invalid @enderror"
-                                            id="is_pos"
-                                            name="is_pos"
-                                            value="1"
-                                            {{ old('is_pos', optional($location->saleAssignment)->is_pos) ? 'checked' : '' }}
-                                        >
-                                        <label class="form-check-label" for="is_pos">
-                                            Gunakan lokasi ini untuk POS
-                                        </label>
-                                        @error('is_pos')
-                                        <div class="invalid-feedback d-block">{{ $message }}</div>
-                                        @enderror
-                                    </div>
-
                                 </div>
 
                                 <div class="col-lg-12 d-flex justify-content-end">

--- a/Modules/Setting/Resources/views/locations/index.blade.php
+++ b/Modules/Setting/Resources/views/locations/index.blade.php
@@ -43,7 +43,7 @@
                                         <td class="align-middle">{{ $location->name }}</td>
                                         <td class="align-middle">{{ $location->setting->company_name }}</td>
                                         <td class="align-middle">
-                                            @if(optional($location->saleAssignment)->is_pos)
+                                            @if($location->saleAssignment?->is_pos)
                                                 <span class="badge badge-success">Ya</span>
                                             @else
                                                 <span class="badge badge-secondary">Tidak</span>


### PR DESCRIPTION
## Summary
- remove `is_pos` validation and persistence from the location controller
- simplify location create and edit forms by dropping the POS checkbox
- render the POS badge from the sale assignment relationship in the index view

## Testing
- php artisan test --testsuite=Feature --filter=SaleLocationConfigurationTest *(fails: missing vendor autoload)*

------
https://chatgpt.com/codex/tasks/task_e_68fcbeb329c08326bd7fa0b55c1afed5