### PR TITLE
Guard forceDeleted listener registration

### DIFF
--- a/Modules/Setting/Entities/SettingSaleLocation.php
+++ b/Modules/Setting/Entities/SettingSaleLocation.php
@@ -54,16 +54,18 @@ class SettingSaleLocation extends BaseModel
             }
         });
 
-        static::forceDeleted(function (SettingSaleLocation $assignment) {
-            $settingIds = collect([
-                $assignment->getOriginal('setting_id'),
-                $assignment->setting_id,
-            ])->filter()->unique()->all();
+        if (method_exists(static::class, 'forceDeleted')) {
+            static::forceDeleted(function (SettingSaleLocation $assignment) {
+                $settingIds = collect([
+                    $assignment->getOriginal('setting_id'),
+                    $assignment->setting_id,
+                ])->filter()->unique()->all();
 
-            if (!empty($settingIds)) {
-                PosLocationResolver::forget(...$settingIds);
-            }
-        });
+                if (!empty($settingIds)) {
+                    PosLocationResolver::forget(...$settingIds);
+                }
+            });
+        }
     }
 
     public function setting(): BelongsTo


### PR DESCRIPTION
## Summary
- avoid registering a forceDeleted event listener when the model does not support it to prevent runtime errors

## Testing
- php artisan test *(fails: missing vendor/autoload.php in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fcc2632ce883268ff695375f4211cd