### PR TITLE
Fix approval status handling in sales return view

### DIFF
--- a/Modules/SalesReturn/Resources/views/show.blade.php
+++ b/Modules/SalesReturn/Resources/views/show.blade.php
@@ -1,5 +1,7 @@
-@php($approvalStatus = strtolower($sale_return->approval_status ?? ''))
-@php($status = strtolower($sale_return->status ?? ''))
+@php
+    $approvalStatus = strtolower($sale_return->approval_status ?? '');
+    $status = strtolower($sale_return->status ?? '');
+@endphp
 @php use Illuminate\Support\Facades\Storage; @endphp
 @extends('layouts.app')
 


### PR DESCRIPTION
## Summary
- ensure the sales return view initializes the approval and status variables using a PHP block to avoid undefined variable errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905be94daa08326a2160a49e28aa69f