### PR TITLE
Persist manual payment flags across Livewire hydrations

### DIFF
--- a/app/Livewire/Pos/Checkout.php
+++ b/app/Livewire/Pos/Checkout.php
@@ -7,6 +7,7 @@ use App\Support\ProductBundleResolver;
 use Gloudemans\Shoppingcart\Facades\Cart;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 use Modules\Product\Entities\Product;
 use Modules\Product\Entities\ProductBundle;
@@ -52,8 +53,10 @@ class Checkout extends Component
     public ?int $posLocationId = null;
     public bool $changeModalHasPositiveChange = false;
     public ?string $changeModalAmount = null;
-    protected bool $paidAmountManuallyUpdated = false;
-    protected ?string $lastChangeModalAmount = null;
+    #[Locked]
+    public bool $paidAmountManuallyUpdated = false;
+    #[Locked]
+    public ?string $lastChangeModalAmount = null;
 
     public function mount($cartInstance, $customers)
     {


### PR DESCRIPTION
## Summary
- persist the checkout component's manual payment tracking flags across Livewire hydrations
- lock the manual payment tracking properties to prevent client-side tampering

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_6905c87ca7f083268bec82f1ac9e6db1