### PR TITLE
Show change modal automatically after POS sale

### DIFF
--- a/resources/views/livewire/pos/includes/checkout-modal.blade.php
+++ b/resources/views/livewire/pos/includes/checkout-modal.blade.php
@@ -223,20 +223,6 @@
                                     </tr>
                                 </table>
                             </div>
-                            <div class="mt-3">
-                                <button type="button"
-                                        class="btn btn-outline-success btn-block"
-                                        wire:click="openChangeModal"
-                                        aria-controls="posChangeModal"
-                                        {{ $hasCashPayment ? '' : 'disabled' }}>
-                                    Tampilkan Kembalian
-                                </button>
-                                @if(! $hasCashPayment)
-                                    <small class="form-text text-muted mt-2">
-                                        Pilih metode pembayaran tunai untuk menampilkan informasi kembalian.
-                                    </small>
-                                @endif
-                            </div>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary
- remove the manual "Tampilkan Kembalian" button from the checkout modal so change is surfaced automatically
- flash the computed cash change due and overpayment flag when storing a POS sale and redirect back to the POS screen
- let the Livewire checkout component consume the flashed change data and dispatch the change modal on load after redirect

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_6905ca0b1ec083269a72ba87f0e2be0a