### PR TITLE
Update POS checkout button label to Bayar

### DIFF
--- a/resources/views/livewire/pos/includes/checkout-modal.blade.php
+++ b/resources/views/livewire/pos/includes/checkout-modal.blade.php
@@ -233,7 +233,7 @@
                             class="btn btn-warning">
                         Simpan Sebagai Dokumen Penjualan
                     </button>
-                    <button type="submit" class="btn btn-primary">Kirim</button>
+                    <button type="submit" class="btn btn-primary">Bayar</button>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
## Summary
- rename the primary submission button in the POS checkout modal to display "Bayar"
- confirm there are no related translations or tests still referencing the old label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905cf7988648326b493c6e836c41eb9