### PR TITLE
Use location-aware stock checks during POS product selection

### DIFF
--- a/app/Livewire/Pos/Checkout.php
+++ b/app/Livewire/Pos/Checkout.php
@@ -271,15 +271,18 @@ class Checkout extends Component
             return;
         }
 
-        if (($product['product_quantity'] ?? 0) <= 0) {
-            session()->flash('message', 'Produk sedang tidak tersedia!');
-            return;
-        }
-
         [$hydratedProduct, $bundles] = $this->resolveProductContext($product);
 
         if (!$hydratedProduct) {
             session()->flash('message', 'Produk tidak dapat dimuat.');
+            return;
+        }
+
+        $convertedQty = max(1, (int) ($hydratedProduct['conversion_factor'] ?? 1));
+        $stockContext = $this->resolveStockForProduct($hydratedProduct, $convertedQty);
+
+        if (!($stockContext['sufficient'] ?? true)) {
+            session()->flash('message', 'Jumlah yang diminta melebihi stok POS yang tersedia.');
             return;
         }
 


### PR DESCRIPTION
## Summary
- update the POS checkout productSelected handler to resolve stock using the same helper that respects the active POS location
- fall back to the existing insufficient stock message when the resolved stock cannot satisfy the request

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6905d1af0ee08326bde360c47c95c370