### PR TITLE
Fix POS serial picker event dispatch

### DIFF
--- a/app/Livewire/Pos/SerialNumberPicker.php
+++ b/app/Livewire/Pos/SerialNumberPicker.php
@@ -131,7 +131,7 @@ class SerialNumberPicker extends Component
                     'location_id' => $row->location_id !== null ? (int)$row->location_id : null,
                 ],
                 'bundle' => $this->bundle,
-            ]);
+            ])->to(Checkout::class);
 
             // UX: show as "recent", clear input, keep modal open for next scan
             array_unshift($this->recent, (string)$row->serial_number);


### PR DESCRIPTION
## Summary
- ensure the POS serial number picker targets the checkout component when dispatching scan events so they are handled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69072ffb7d588326a6b2cdd52d09e1a1