### PR TITLE
Filter POS serial lookups to unsold serial numbers

### DIFF
--- a/app/Livewire/SearchProduct.php
+++ b/app/Livewire/SearchProduct.php
@@ -119,6 +119,7 @@ class SearchProduct extends Component
         ) st ON st.product_id = p.id
         WHERE LOWER(psn.serial_number) = LOWER(:code)
           AND psn.is_broken = 0
+          AND psn.dispatch_detail_id IS NULL
           AND {serial_filter}
         LIMIT 1
     ";
@@ -477,6 +478,7 @@ class SearchProduct extends Component
         ) st ON st.product_id = p.id
         LEFT JOIN units ub ON ub.id = p.base_unit_id
         WHERE psn.is_broken = 0
+          AND psn.dispatch_detail_id IS NULL
           AND {serial_location_filter}
     ) results
     WHERE (


### PR DESCRIPTION
## Summary
- ignore serial numbers already dispatched when resolving exact serial scans in POS
- hide dispatched serial numbers from autocomplete suggestions in the POS search modal

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690732dd55cc8326a4c246673c88010c