### PR TITLE
Fix POS serial lookup filters and stock validation

### DIFF
--- a/app/Livewire/Pos/Checkout.php
+++ b/app/Livewire/Pos/Checkout.php
@@ -1336,17 +1336,21 @@ class Checkout extends Component
                     }
 
                     if (isset($serialStock['non_tax'])) {
-                        $locationStocks[$locationId]['available_non_tax'] = max(
-                            $locationStocks[$locationId]['available_non_tax'] ?? 0,
-                            $serialStock['non_tax']
-                        );
+                        $serialCount = max(0, (int) $serialStock['non_tax']);
+                        $existing = max(0, (int) ($locationStocks[$locationId]['available_non_tax'] ?? 0));
+
+                        $locationStocks[$locationId]['available_non_tax'] = $existing > 0
+                            ? min($existing, $serialCount)
+                            : $serialCount;
                     }
 
                     if (isset($serialStock['tax'])) {
-                        $locationStocks[$locationId]['available_tax'] = max(
-                            $locationStocks[$locationId]['available_tax'] ?? 0,
-                            $serialStock['tax']
-                        );
+                        $serialCount = max(0, (int) $serialStock['tax']);
+                        $existing = max(0, (int) ($locationStocks[$locationId]['available_tax'] ?? 0));
+
+                        $locationStocks[$locationId]['available_tax'] = $existing > 0
+                            ? min($existing, $serialCount)
+                            : $serialCount;
                     }
 
                     if (isset($serialStock['tax_candidates'])) {

--- a/app/Livewire/Pos/Checkout.php
+++ b/app/Livewire/Pos/Checkout.php
@@ -298,6 +298,26 @@ class Checkout extends Component
             return;
         }
 
+        $requiresSerial = $this->productRequiresSerial($hydratedProduct);
+
+        if ($requiresSerial && empty($pendingSerials)) {
+            $this->serialSelectionContext = [
+                'product' => $hydratedProduct,
+                'bundle'  => null,
+            ];
+
+            $expectedCount = max(1, (int) ($hydratedProduct['conversion_factor'] ?? 1));
+
+            $this->dispatch('openSerialPicker', [
+                'product_id'     => (int) $hydratedProduct['id'],
+                'expected_count' => $expectedCount,
+                'bundle'         => null,
+            ]);
+
+            $this->resetBundleState();
+            return;
+        }
+
         if ($this->promptBundleSelection($hydratedProduct, $bundles, $pendingSerials)) {
             return;
         }


### PR DESCRIPTION
## Summary
- ensure serial scans in POS count unsold serial numbers per location so available stock is surfaced even when product_stocks is empty
- allow POS serial lookups when no sale locations are configured by falling back to a neutral location filter
- extend checkout stock validation to honour available serial numbers per POS location for serialised products

## Testing
- php -l app/Livewire/SearchProduct.php
- php -l app/Livewire/Pos/Checkout.php

------
https://chatgpt.com/codex/tasks/task_e_690732dd55cc8326a4c246673c88010c