### PR TITLE
Add standalone purchase receiving screen guarded by new permission

### DIFF
--- a/Modules/Purchase/Http/Controllers/PurchaseController.php
+++ b/Modules/Purchase/Http/Controllers/PurchaseController.php
@@ -41,6 +41,13 @@ class PurchaseController extends Controller
         return $dataTable->render('purchase::index');
     }
 
+    public function receivingIndex(): Factory|Application|View|\Illuminate\Contracts\Foundation\Application
+    {
+        abort_if(Gate::denies('purchaseReceivings.access'), 403);
+
+        return view('purchase::receiving.index');
+    }
+
 
     public function create(): Factory|Application|View|\Illuminate\Contracts\Foundation\Application
     {

--- a/Modules/Purchase/Resources/views/receiving/index.blade.php
+++ b/Modules/Purchase/Resources/views/receiving/index.blade.php
@@ -1,0 +1,34 @@
+@extends('layouts.app')
+
+@section('title', 'Penerimaan Barang')
+
+@section('breadcrumb')
+    <ol class="breadcrumb border-0 m-0">
+        <li class="breadcrumb-item"><a href="{{ route('home') }}">Beranda</a></li>
+        <li class="breadcrumb-item"><a href="{{ route('purchases.index') }}">Pembelian</a></li>
+        <li class="breadcrumb-item active">Penerimaan Barang</li>
+    </ol>
+@endsection
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-body">
+                        <p class="text-muted mb-3">
+                            Menampilkan pembelian yang sudah disetujui atau sebagian diterima untuk diproses penerimaan barang.
+                        </p>
+
+                        <div class="table-responsive">
+                            <livewire:purchase.purchase-table :status-filter="[
+                                \Modules\Purchase\Entities\Purchase::STATUS_APPROVED,
+                                \Modules\Purchase\Entities\Purchase::STATUS_RECEIVED_PARTIALLY,
+                            ]" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/Modules/Purchase/Routes/web.php
+++ b/Modules/Purchase/Routes/web.php
@@ -49,6 +49,9 @@ Route::group(['middleware' => ['auth', 'role.setting']], function () {
     })->name('purchases.pdf');
 
     //Purchases
+    Route::get('/purchases/receiving', [PurchaseController::class, 'receivingIndex'])
+        ->name('purchases.receiving.index')
+        ->middleware('can:purchaseReceivings.access');
     Route::get('/purchases/receivings/{purchase_id}', [PurchaseController::class, 'showReceivings'])
         ->name('purchases.receivings');
     Route::post('/purchases/{purchase}/receive', [PurchaseController::class, 'storeReceive'])->name('purchases.storeReceive');

--- a/Modules/User/Database/Seeders/PermissionsTableSeeder.php
+++ b/Modules/User/Database/Seeders/PermissionsTableSeeder.php
@@ -132,6 +132,7 @@ class PermissionsTableSeeder extends Seeder
             'purchases.receive',
             'purchases.approval',
             'purchases.view',
+            'purchaseReceivings.access',
             'purchaseReports.access',
 
             // Purchase Payments

--- a/Modules/User/Resources/views/roles/create.blade.php
+++ b/Modules/User/Resources/views/roles/create.blade.php
@@ -101,6 +101,7 @@
                                             'purchases.receive'  => 'Penerimaan',
                                             'purchases.approval' => 'Persetujuan',
                                             'purchases.view'     => 'Lihat Detail',
+                                            'purchaseReceivings.access' => 'Akses Penerimaan Barang',
                                         ],
 
                                         'Laporan Pembelian' => [

--- a/Modules/User/Resources/views/roles/edit.blade.php
+++ b/Modules/User/Resources/views/roles/edit.blade.php
@@ -100,6 +100,7 @@
                                             'purchases.receive'  => 'Penerimaan',
                                             'purchases.approval' => 'Persetujuan',
                                             'purchases.view'     => 'Lihat Detail',
+                                            'purchaseReceivings.access' => 'Akses Penerimaan Barang',
                                         ],
 
                                         'Laporan Pembelian' => [

--- a/app/Livewire/Purchase/PurchaseTable.php
+++ b/app/Livewire/Purchase/PurchaseTable.php
@@ -16,13 +16,15 @@ class PurchaseTable extends Component
     public $sortField = 'created_at';
     public $sortDirection = 'desc';
     public $settingId;
+    public $statusFilter = null;
 
     protected $updatesQueryString = ['search', 'page', 'sortField', 'sortDirection'];
 
-    public function mount($settingId = null)
+    public function mount($settingId = null, $statusFilter = null)
     {
         // if you pass it in from the parent, use that; otherwise, fall back to the logged-in user’s
         $this->settingId = $settingId ?? session('setting_id');
+        $this->statusFilter = is_array($statusFilter) ? $statusFilter : (is_null($statusFilter) ? null : [$statusFilter]);
     }
 
     public function updatedSearch()
@@ -58,6 +60,9 @@ class PurchaseTable extends Component
         $query = Purchase::query()
             ->with(['supplier', 'tags'])
             ->where('setting_id', $this->settingId)
+            ->when(! empty($this->statusFilter), function ($q) {
+                $q->whereIn('status', $this->statusFilter);
+            })
             ->when($this->search, function ($q) {
                 $q->where(function ($qq) {
                     $search = $this->search;

--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -96,7 +96,7 @@
     </li>
 @endcanany
 
-@canany(['purchases.access', 'purchaseReturns.access'])
+@canany(['purchases.access', 'purchaseReturns.access', 'purchaseReceivings.access'])
     <li class="c-sidebar-nav-item c-sidebar-nav-dropdown {{ request()->routeIs('purchases.*') || request()->routeIs('purchase-payments*') ? 'c-show' : '' }}">
         <a class="c-sidebar-nav-link c-sidebar-nav-dropdown-toggle" href="#">
             <i class="c-sidebar-nav-icon bi bi-bag" style="line-height: 1;"></i> Pembelian
@@ -118,6 +118,17 @@
                     <a class="c-sidebar-nav-link {{ request()->routeIs('purchases.index') ? 'c-active' : '' }}"
                        href="{{ route('purchases.index') }}">
                         <i class="c-sidebar-nav-icon bi bi-journals" style="line-height: 1;"></i> Semua Pembelian
+                    </a>
+                </li>
+            </ul>
+        @endcan
+
+        @can('purchaseReceivings.access')
+            <ul class="c-sidebar-nav-dropdown-items">
+                <li class="c-sidebar-nav-item">
+                    <a class="c-sidebar-nav-link {{ request()->routeIs('purchases.receiving.*') ? 'c-active' : '' }}"
+                       href="{{ route('purchases.receiving.index') }}">
+                        <i class="c-sidebar-nav-icon bi bi-box-seam" style="line-height: 1;"></i> Penerimaan Barang
                     </a>
                 </li>
             </ul>


### PR DESCRIPTION
## Summary
- add purchaseReceivings.access permission and expose it on the role forms
- create a dedicated "Penerimaan Barang" page that lists approved or partially received purchases via a new controller action and route
- update the purchase table component and sidebar menu to support the receiving view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6909f0e111608326ad1069bff4ff0feb