### PR TITLE
Enhance receiving index filtering

### DIFF
--- a/Modules/Purchase/Http/Controllers/PurchaseController.php
+++ b/Modules/Purchase/Http/Controllers/PurchaseController.php
@@ -44,11 +44,18 @@ class PurchaseController extends Controller
     /**
      * Display the purchase receiving landing page.
      */
-    public function receivingIndex(): Factory|Application|View|\Illuminate\Contracts\Foundation\Application
+    public function receivingIndex(Request $request): Factory|Application|View|\Illuminate\Contracts\Foundation\Application
     {
         abort_if(Gate::denies('purchaseReceivings.access'), 403);
 
-        return view('purchase::receiving.index');
+        $purchase = null;
+
+        if ($request->filled('purchase_id')) {
+            $purchase = Purchase::findOrFail($request->input('purchase_id'));
+            $this->ensurePurchaseBelongsToCurrentSetting($purchase);
+        }
+
+        return view('purchase::receiving.filtered-index', compact('purchase'));
     }
 
 

--- a/Modules/Purchase/Resources/views/receiving/filtered-index.blade.php
+++ b/Modules/Purchase/Resources/views/receiving/filtered-index.blade.php
@@ -1,0 +1,40 @@
+@extends('layouts.app')
+
+@section('title', 'Penerimaan Barang')
+
+@section('breadcrumb')
+    <ol class="breadcrumb border-0 m-0">
+        <li class="breadcrumb-item"><a href="{{ route('home') }}">Beranda</a></li>
+        <li class="breadcrumb-item"><a href="{{ route('purchases.index') }}">Pembelian</a></li>
+        <li class="breadcrumb-item active">Penerimaan Barang</li>
+    </ol>
+@endsection
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-body">
+                        <p class="text-muted mb-3">
+                            Menampilkan pembelian yang sudah disetujui atau sebagian diterima untuk diproses penerimaan barang.
+                        </p>
+
+                        @if ($purchase)
+                            <div class="alert alert-info" role="alert">
+                                Menyaring daftar untuk pembelian dengan referensi <strong>{{ $purchase->reference }}</strong>.
+                            </div>
+                        @endif
+
+                        <div class="table-responsive">
+                            <livewire:purchase.purchase-table :status-filter="[
+                                \Modules\Purchase\Entities\Purchase::STATUS_APPROVED,
+                                \Modules\Purchase\Entities\Purchase::STATUS_RECEIVED_PARTIALLY,
+                            ]" :purchase-id="optional($purchase)->id" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/app/Livewire/Purchase/PurchaseTable.php
+++ b/app/Livewire/Purchase/PurchaseTable.php
@@ -17,14 +17,16 @@ class PurchaseTable extends Component
     public $sortDirection = 'desc';
     public $settingId;
     public $statusFilter = null;
+    public $purchaseId = null;
 
     protected $updatesQueryString = ['search', 'page', 'sortField', 'sortDirection'];
 
-    public function mount($settingId = null, $statusFilter = null)
+    public function mount($settingId = null, $statusFilter = null, $purchaseId = null)
     {
         // if you pass it in from the parent, use that; otherwise, fall back to the logged-in user’s
         $this->settingId = $settingId ?? session('setting_id');
         $this->statusFilter = is_array($statusFilter) ? $statusFilter : (is_null($statusFilter) ? null : [$statusFilter]);
+        $this->purchaseId = $purchaseId;
     }
 
     public function updatedSearch()
@@ -62,6 +64,9 @@ class PurchaseTable extends Component
             ->where('setting_id', $this->settingId)
             ->when(! empty($this->statusFilter), function ($q) {
                 $q->whereIn('status', $this->statusFilter);
+            })
+            ->when(! empty($this->purchaseId), function ($q) {
+                $q->where('id', $this->purchaseId);
             })
             ->when($this->search, function ($q) {
                 $q->where(function ($qq) {


### PR DESCRIPTION
## Summary
- guard the receiving index against unauthorized access and ensure optional purchase targets belong to the active setting
- add a dedicated receiving view to host the filtered purchase table with optional purchase context
- extend the purchase Livewire table to allow filtering by a specific purchase id

## Testing
- php artisan test *(fails: missing vendor/autoload.php in container)*

------
https://chatgpt.com/codex/tasks/task_e_6909f65d879483268235aaa7d4ec14f0