### PR TITLE
Add supervisor POS session monitoring dashboard

### DIFF
--- a/Modules/Sale/Http/Controllers/PosController.php
+++ b/Modules/Sale/Http/Controllers/PosController.php
@@ -41,6 +41,13 @@ class PosController extends Controller
         return view('sale::pos.session');
     }
 
+    public function monitor()
+    {
+        abort_if(Gate::denies('reports.access'), 403);
+
+        return view('sale::pos.supervisor');
+    }
+
     public function index() {
         abort_if(Gate::denies('pos.access'), 403);
         Cart::instance('sale')->destroy();

--- a/Modules/Sale/Resources/views/pos/supervisor.blade.php
+++ b/Modules/Sale/Resources/views/pos/supervisor.blade.php
@@ -1,0 +1,16 @@
+@extends('layouts.app')
+
+@section('title', 'Monitoring Sesi POS')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                @include('utils.alerts')
+            </div>
+            <div class="col-12">
+                <livewire:pos.session-monitor />
+            </div>
+        </div>
+    </div>
+@endsection

--- a/Modules/Sale/Routes/web.php
+++ b/Modules/Sale/Routes/web.php
@@ -19,6 +19,9 @@ use Modules\Sale\Http\Controllers\SaleController;
 Route::group(['middleware' => ['auth', 'role.setting']], function () {
 
     Route::get('/app/pos/session', [PosController::class, 'session'])->name('app.pos.session');
+    Route::get('/app/pos/sessions/monitor', [PosController::class, 'monitor'])
+        ->name('app.pos.monitor')
+        ->middleware('can:reports.access');
 
     Route::middleware('pos.session')->group(function () {
         //POS

--- a/Modules/Setting/Database/Migrations/2026_03_10_000002_add_pos_monitoring_thresholds.php
+++ b/Modules/Setting/Database/Migrations/2026_03_10_000002_add_pos_monitoring_thresholds.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->unsignedInteger('pos_idle_threshold_minutes')->default(30)->after('sale_prefix_document');
+            $table->decimal('pos_default_cash_threshold', 15, 2)->default(0)->after('pos_idle_threshold_minutes');
+        });
+
+        Schema::table('locations', function (Blueprint $table) {
+            $table->decimal('pos_cash_threshold', 15, 2)->nullable()->after('name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('locations', function (Blueprint $table) {
+            $table->dropColumn('pos_cash_threshold');
+        });
+
+        Schema::table('settings', function (Blueprint $table) {
+            $table->dropColumn(['pos_idle_threshold_minutes', 'pos_default_cash_threshold']);
+        });
+    }
+};

--- a/Modules/Setting/Database/Seeders/SettingDatabaseSeeder.php
+++ b/Modules/Setting/Database/Seeders/SettingDatabaseSeeder.php
@@ -25,7 +25,9 @@ class SettingDatabaseSeeder extends Seeder
             'company_address' => 'Bima, NTB',
             'document_prefix' => 'TS',
             'purchase_prefix_document' => 'PR',
-            'sale_prefix_document' => 'SL'
+            'sale_prefix_document' => 'SL',
+            'pos_idle_threshold_minutes' => 30,
+            'pos_default_cash_threshold' => 0,
         ]);
 
         // Call additional seeders

--- a/Modules/Setting/Entities/Location.php
+++ b/Modules/Setting/Entities/Location.php
@@ -12,6 +12,10 @@ class Location extends BaseModel
 {
     protected $guarded = [];
 
+    protected $casts = [
+        'pos_cash_threshold' => 'decimal:2',
+    ];
+
     protected static function booted(): void
     {
         static::created(function (Location $location) {

--- a/Modules/Setting/Entities/Setting.php
+++ b/Modules/Setting/Entities/Setting.php
@@ -14,6 +14,11 @@ class Setting extends BaseModel
 {
     protected $guarded = [];
 
+    protected $casts = [
+        'pos_idle_threshold_minutes' => 'integer',
+        'pos_default_cash_threshold' => 'decimal:2',
+    ];
+
     protected $with = ['currency'];
 
     public function currency(): BelongsTo

--- a/Modules/Setting/Http/Controllers/SettingController.php
+++ b/Modules/Setting/Http/Controllers/SettingController.php
@@ -40,6 +40,8 @@ class SettingController extends Controller
             'document_prefix'          => $request->document_prefix,
             'purchase_prefix_document' => $request->purchase_prefix_document,
             'sale_prefix_document'     => $request->sale_prefix_document,
+            'pos_idle_threshold_minutes' => $request->pos_idle_threshold_minutes,
+            'pos_default_cash_threshold' => $request->pos_default_cash_threshold,
         ];
 
         // Uppercase text-type columns
@@ -63,6 +65,11 @@ class SettingController extends Controller
             $data['company_phone'] = trim((string) $data['company_phone']);
         }
 
+        $data['pos_idle_threshold_minutes'] = max(0, (int) ($data['pos_idle_threshold_minutes'] ?? 0));
+        $data['pos_default_cash_threshold'] = $data['pos_default_cash_threshold'] !== null
+            ? round((float) $data['pos_default_cash_threshold'], 2)
+            : 0.0;
+
         // Persist
         $setting->update($data);
         $setting = $setting->fresh();
@@ -78,6 +85,8 @@ class SettingController extends Controller
                 'document_prefix',
                 'purchase_prefix_document',
                 'sale_prefix_document',
+                'pos_idle_threshold_minutes',
+                'pos_default_cash_threshold',
             ];
 
             $current = session('user_settings');

--- a/Modules/Setting/Http/Requests/StoreSettingsRequest.php
+++ b/Modules/Setting/Http/Requests/StoreSettingsRequest.php
@@ -22,7 +22,9 @@ class StoreSettingsRequest extends FormRequest
             'purchase_prefix_document' => 'required|string|max:255',
             'sale_prefix_document' => 'required|string|max:255',
             'company_address' => 'required|string|max:500',
-            'footer_text' => 'nullable|string|max:255'
+            'footer_text' => 'nullable|string|max:255',
+            'pos_idle_threshold_minutes' => 'nullable|integer|min:0|max:1440',
+            'pos_default_cash_threshold' => 'nullable|numeric|min:0',
         ];
     }
 

--- a/Modules/Setting/Resources/views/index.blade.php
+++ b/Modules/Setting/Resources/views/index.blade.php
@@ -77,6 +77,26 @@
                             </div>
 
                             <div class="form-row">
+                                <div class="col-lg-4">
+                                    <div class="form-group">
+                                        <label for="pos_idle_threshold_minutes">Peringatan Waktu Idle (menit)</label>
+                                        <input type="number" min="0" class="form-control" name="pos_idle_threshold_minutes"
+                                               value="{{ old('pos_idle_threshold_minutes', $settings->pos_idle_threshold_minutes ?? 0) }}">
+                                        <small class="text-muted">Atur ke 0 untuk menonaktifkan peringatan idle kasir.</small>
+                                    </div>
+                                </div>
+
+                                <div class="col-lg-4">
+                                    <div class="form-group">
+                                        <label for="pos_default_cash_threshold">Ambang Kas Default POS</label>
+                                        <input type="number" step="0.01" min="0" class="form-control" name="pos_default_cash_threshold"
+                                               value="{{ old('pos_default_cash_threshold', $settings->pos_default_cash_threshold ?? 0) }}">
+                                        <small class="text-muted">Dipakai saat lokasi belum memiliki ambang kas khusus.</small>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="form-row">
                                 <div class="col-lg-12">
                                     <div class="form-group">
                                         <label for="company_address">Alamat Perusahaan <span class="text-danger">*</span></label>

--- a/Modules/Setting/Resources/views/locations/create.blade.php
+++ b/Modules/Setting/Resources/views/locations/create.blade.php
@@ -43,6 +43,25 @@
 
                                 </div>
 
+                                <div class="col-lg-6">
+                                    <div class="form-group">
+                                        <label for="pos_cash_threshold">Ambang Kas POS (opsional)</label>
+                                        <input
+                                            type="number"
+                                            step="0.01"
+                                            min="0"
+                                            id="pos_cash_threshold"
+                                            name="pos_cash_threshold"
+                                            value="{{ old('pos_cash_threshold', $defaultCashThreshold) }}"
+                                            class="form-control @error('pos_cash_threshold') is-invalid @enderror"
+                                        >
+                                        <small class="text-muted">Gunakan untuk memicu peringatan kas berlebih di lokasi ini.</small>
+                                        @error('pos_cash_threshold')
+                                        <div class="invalid-feedback d-block">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+                                </div>
+
                                 <div class="col-lg-12 d-flex justify-content-end">
                                     <div class="form-group">
                                         <a href="{{ route('locations.index') }}" class="btn btn-secondary mr-2">Kembali</a>

--- a/Modules/Setting/Resources/views/locations/edit.blade.php
+++ b/Modules/Setting/Resources/views/locations/edit.blade.php
@@ -44,6 +44,25 @@
 
                                 </div>
 
+                                <div class="col-lg-6">
+                                    <div class="form-group">
+                                        <label for="pos_cash_threshold">Ambang Kas POS (opsional)</label>
+                                        <input
+                                            type="number"
+                                            step="0.01"
+                                            min="0"
+                                            id="pos_cash_threshold"
+                                            name="pos_cash_threshold"
+                                            class="form-control @error('pos_cash_threshold') is-invalid @enderror"
+                                            value="{{ old('pos_cash_threshold', $location->pos_cash_threshold ?? $defaultCashThreshold) }}"
+                                        >
+                                        <small class="text-muted">Biarkan kosong untuk mengikuti ambang default POS.</small>
+                                        @error('pos_cash_threshold')
+                                        <div class="invalid-feedback d-block">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+                                </div>
+
                                 <div class="col-lg-12 d-flex justify-content-end">
                                     <div class="form-group">
                                         <a href="{{ route('locations.index') }}" class="btn btn-secondary mr-2">Kembali</a>

--- a/Modules/Setting/Resources/views/locations/index.blade.php
+++ b/Modules/Setting/Resources/views/locations/index.blade.php
@@ -32,6 +32,7 @@
                                     <th class="align-middle">No.</th>
                                     <th class="align-middle">Nama</th>
                                     <th class="align-middle">Bisnis</th>
+                                    <th class="align-middle">Ambang Kas</th>
                                     <th class="align-middle">POS</th>
                                     <th class="align-middle">Aksi</th>
                                 </tr>
@@ -42,6 +43,12 @@
                                         <td class="align-middle">{{ $key + 1 }}</td>
                                         <td class="align-middle">{{ $location->name }}</td>
                                         <td class="align-middle">{{ $location->setting->company_name }}</td>
+                                        <td class="align-middle">
+                                            @php
+                                                $threshold = $location->pos_cash_threshold ?? $location->setting?->pos_default_cash_threshold ?? 0;
+                                            @endphp
+                                            {{ $threshold > 0 ? format_currency($threshold) : '—' }}
+                                        </td>
                                         <td class="align-middle">
                                             @if($location->saleAssignment?->is_pos)
                                                 <span class="badge badge-success">Ya</span>

--- a/app/Livewire/Pos/SessionMonitor.php
+++ b/app/Livewire/Pos/SessionMonitor.php
@@ -1,0 +1,257 @@
+<?php
+
+namespace App\Livewire\Pos;
+
+use App\Models\PosSession;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Livewire\Component;
+use Modules\Setting\Entities\Location;
+use Modules\Setting\Entities\Setting;
+
+class SessionMonitor extends Component
+{
+    public array $sessions = [];
+
+    public Collection $locations;
+
+    public string $statusFilter = '';
+
+    public string $locationFilter = '';
+
+    public bool $alertsOnly = false;
+
+    public int $idleThresholdMinutes = 0;
+
+    public float $defaultCashThreshold = 0.0;
+
+    protected array $alertedSessionIds = [];
+
+    protected $queryString = [
+        'statusFilter' => ['except' => ''],
+        'locationFilter' => ['except' => ''],
+        'alertsOnly' => ['except' => false],
+    ];
+
+    public function mount(): void
+    {
+        $settingId = session('setting_id');
+        $setting = $settingId ? Setting::find($settingId) : null;
+
+        $this->idleThresholdMinutes = (int) ($setting?->pos_idle_threshold_minutes ?? 0);
+        $this->defaultCashThreshold = (float) ($setting?->pos_default_cash_threshold ?? 0);
+
+        $this->locations = Location::query()
+            ->where('setting_id', $settingId)
+            ->orderBy('name')
+            ->get(['id', 'name', 'pos_cash_threshold']);
+
+        $this->refreshSessions();
+    }
+
+    public function updatedStatusFilter(): void
+    {
+        $this->refreshSessions();
+    }
+
+    public function updatedLocationFilter(): void
+    {
+        $this->refreshSessions();
+    }
+
+    public function updatedAlertsOnly(): void
+    {
+        $this->refreshSessions();
+    }
+
+    public function refreshSessions(): void
+    {
+        $settingId = session('setting_id');
+
+        $query = PosSession::query()
+            ->with(['cashier:id,name,email', 'location:id,name,setting_id,pos_cash_threshold'])
+            ->withSum(['sales as sales_total' => function ($builder) use ($settingId) {
+                if ($settingId) {
+                    $builder->where('setting_id', $settingId);
+                }
+            }], 'total_amount')
+            ->withSum(['payments as cash_payments_total' => function ($builder) {
+                $builder->whereHas('paymentMethod', function ($method) {
+                    $method->where('is_cash', true);
+                });
+            }], 'amount')
+            ->withMax(['sales as latest_sale_at'], 'created_at')
+            ->withMax(['payments as latest_payment_at'], 'created_at')
+            ->latest('id');
+
+        if ($settingId) {
+            $query->where(function ($builder) use ($settingId) {
+                $builder->whereHas('location', function ($locationQuery) use ($settingId) {
+                    $locationQuery->where('setting_id', $settingId);
+                })->orWhere(function ($subQuery) use ($settingId) {
+                    $subQuery->whereNull('location_id')
+                        ->whereHas('cashier.settings', function ($settings) use ($settingId) {
+                            $settings->where('settings.id', $settingId);
+                        });
+                });
+            });
+        }
+
+        if ($this->statusFilter !== '') {
+            $query->where('status', $this->statusFilter);
+        }
+
+        if ($this->locationFilter !== '') {
+            $query->where('location_id', $this->locationFilter);
+        }
+
+        $sessions = $query->get();
+
+        $mapped = $sessions->map(function (PosSession $session) {
+            $lastActivity = $this->resolveLastActivity($session);
+            $threshold = $this->resolveCashThreshold($session);
+            $estimatedCash = $this->calculateEstimatedCash($session);
+
+            $alerts = [
+                'idle' => $this->isIdle($session, $lastActivity),
+                'cash' => $this->isOverCashThreshold($estimatedCash, $threshold),
+            ];
+
+            return [
+                'id' => $session->id,
+                'cashier' => $session->cashier?->name ?? '—',
+                'device' => $session->device_name ?? '—',
+                'location' => $session->location?->name ?? '—',
+                'status' => $session->status,
+                'cash_float' => (float) $session->cash_float,
+                'sales_total' => (float) ($session->sales_total ?? 0),
+                'cash_payments_total' => (float) ($session->cash_payments_total ?? 0),
+                'estimated_cash' => $estimatedCash,
+                'last_activity_at' => $lastActivity?->toDateTimeString(),
+                'last_activity_for_humans' => $lastActivity?->diffForHumans() ?? '—',
+                'threshold' => $threshold,
+                'alerts' => $alerts,
+                'started_at' => $session->started_at,
+            ];
+        });
+
+        if ($this->alertsOnly) {
+            $mapped = $mapped->filter(function ($session) {
+                return $session['alerts']['idle'] || $session['alerts']['cash'];
+            })->values();
+        }
+
+        $this->sessions = $mapped->all();
+
+        $this->emitAlertToasts($mapped);
+    }
+
+    public function render()
+    {
+        return view('livewire.pos.session-monitor');
+    }
+
+    protected function resolveCashThreshold(PosSession $session): ?float
+    {
+        $threshold = optional($session->location)->pos_cash_threshold ?? $this->defaultCashThreshold;
+
+        if ($threshold === null) {
+            return null;
+        }
+
+        $threshold = round((float) $threshold, 2);
+
+        return $threshold > 0 ? $threshold : null;
+    }
+
+    protected function calculateEstimatedCash(PosSession $session): float
+    {
+        if ($session->status === PosSession::STATUS_CLOSED && $session->actual_cash !== null) {
+            return (float) $session->actual_cash;
+        }
+
+        $base = (float) ($session->cash_float ?? 0);
+        $cashIn = (float) ($session->cash_payments_total ?? 0);
+
+        return round($base + $cashIn, 2);
+    }
+
+    protected function resolveLastActivity(PosSession $session): ?Carbon
+    {
+        $timestamps = collect([
+            $session->latest_sale_at,
+            $session->latest_payment_at,
+            $session->resumed_at,
+            $session->started_at,
+        ])->filter();
+
+        if ($session->status === PosSession::STATUS_PAUSED && $session->paused_at) {
+            $timestamps->push($session->paused_at);
+        }
+
+        if ($timestamps->isEmpty()) {
+            return null;
+        }
+
+        return Carbon::parse($timestamps->max());
+    }
+
+    protected function isIdle(PosSession $session, ?Carbon $lastActivity): bool
+    {
+        if ($this->idleThresholdMinutes <= 0 || $session->status !== PosSession::STATUS_ACTIVE) {
+            return false;
+        }
+
+        $cutoff = Carbon::now()->subMinutes($this->idleThresholdMinutes);
+
+        if (! $lastActivity) {
+            return true;
+        }
+
+        return $lastActivity->lessThan($cutoff);
+    }
+
+    protected function isOverCashThreshold(float $estimatedCash, ?float $threshold): bool
+    {
+        if ($threshold === null) {
+            return false;
+        }
+
+        return $estimatedCash > $threshold;
+    }
+
+    protected function emitAlertToasts(Collection $sessions): void
+    {
+        $alerting = $sessions->filter(function ($session) {
+            return $session['alerts']['idle'] || $session['alerts']['cash'];
+        });
+
+        $newAlerts = $alerting->reject(function ($session) {
+            return in_array($session['id'], $this->alertedSessionIds, true);
+        });
+
+        foreach ($newAlerts as $session) {
+            $problems = [];
+
+            if ($session['alerts']['idle']) {
+                $problems[] = 'idle terlalu lama';
+            }
+
+            if ($session['alerts']['cash']) {
+                $problems[] = 'kas melebihi ambang';
+            }
+
+            $this->dispatchBrowserEvent('pos-session-alert', [
+                'message' => sprintf(
+                    'Sesi %s di %s %s.',
+                    $session['cashier'] ?: 'Tanpa kasir',
+                    $session['device'] ?: 'perangkat tidak dikenal',
+                    implode(' dan ', $problems)
+                ),
+                'type' => 'warning',
+            ]);
+        }
+
+        $this->alertedSessionIds = $alerting->pluck('id')->all();
+    }
+}

--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -21,7 +21,7 @@
 <li class="c-sidebar-nav-divider"></li>
 
 @can('reports.access')
-    <li class="c-sidebar-nav-item c-sidebar-nav-dropdown {{ request()->routeIs('reports.mekari-converter.*') ? 'c-show' : '' }}">
+    <li class="c-sidebar-nav-item c-sidebar-nav-dropdown {{ request()->routeIs('reports.mekari-converter.*') || request()->routeIs('reports.mekari-invoice-generator.*') || request()->routeIs('reports.purchase-report.index') || request()->routeIs('app.pos.monitor') ? 'c-show' : '' }}">
         <a class="c-sidebar-nav-link c-sidebar-nav-dropdown-toggle" href="#">
             <i class="c-sidebar-nav-icon bi bi-file-earmark-spreadsheet" style="line-height: 1;"></i> Laporan
         </a>
@@ -46,6 +46,15 @@
                 <a class="c-sidebar-nav-link {{ request()->routeIs('reports.purchase-report.index') ? 'c-active' : '' }}"
                    href="{{ route('reports.purchase-report.index') }}">
                     <i class="c-sidebar-nav-icon bi bi-clipboard-data" style="line-height: 1;"></i> Laporan Pembelian
+                </a>
+            </li>
+        </ul>
+
+        <ul class="c-sidebar-nav-dropdown-items">
+            <li class="c-sidebar-nav-item">
+                <a class="c-sidebar-nav-link {{ request()->routeIs('app.pos.monitor') ? 'c-active' : '' }}"
+                   href="{{ route('app.pos.monitor') }}">
+                    <i class="c-sidebar-nav-icon bi bi-cash-stack" style="line-height: 1;"></i> Monitoring POS
                 </a>
             </li>
         </ul>

--- a/resources/views/livewire/pos/session-monitor.blade.php
+++ b/resources/views/livewire/pos/session-monitor.blade.php
@@ -1,0 +1,147 @@
+<div class="card border-0 shadow-sm" wire:poll.15s="refreshSessions">
+    <div class="card-header d-flex flex-wrap justify-content-between align-items-center">
+        <div>
+            <h5 class="mb-0">Dashboard Sesi POS</h5>
+            <small class="text-muted">Pantau kasir, perangkat, dan kas di laci secara langsung.</small>
+        </div>
+        <div class="text-right">
+            <span class="badge badge-info mr-1">Idle &gt; {{ $idleThresholdMinutes }} menit</span>
+            <span class="badge badge-secondary">Ambang kas default: {{ format_currency($defaultCashThreshold ?? 0) }}</span>
+        </div>
+    </div>
+
+    <div class="card-body">
+        <div class="form-row align-items-end">
+            <div class="col-md-3">
+                <div class="form-group">
+                    <label for="statusFilter" class="font-weight-bold">Status</label>
+                    <select wire:model="statusFilter" id="statusFilter" class="form-control">
+                        <option value="">Semua Status</option>
+                        <option value="active">Aktif</option>
+                        <option value="paused">Jeda</option>
+                        <option value="closed">Tutup</option>
+                    </select>
+                </div>
+            </div>
+
+            <div class="col-md-3">
+                <div class="form-group">
+                    <label for="locationFilter" class="font-weight-bold">Lokasi</label>
+                    <select wire:model="locationFilter" id="locationFilter" class="form-control">
+                        <option value="">Semua Lokasi</option>
+                        @foreach($locations as $location)
+                            <option value="{{ $location->id }}">{{ $location->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
+            </div>
+
+            <div class="col-md-3">
+                <div class="form-group mb-0">
+                    <div class="form-check mt-4">
+                        <input class="form-check-input" type="checkbox" id="alertsOnly" wire:model="alertsOnly">
+                        <label class="form-check-label" for="alertsOnly">Tampilkan yang diberi peringatan saja</label>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-3 text-md-right">
+                <div class="small text-muted">Memperbarui otomatis setiap 15 detik.</div>
+                <div class="small text-muted">Gunakan filter untuk mempersempit fokus supervisor.</div>
+            </div>
+        </div>
+
+        <div class="table-responsive position-relative">
+            <div wire:loading.flex class="position-absolute w-100 h-100 justify-content-center align-items-center"
+                 style="top:0;left:0;background:rgba(255,255,255,0.7);z-index:10;">
+                <div class="spinner-border text-primary" role="status">
+                    <span class="sr-only">Loading...</span>
+                </div>
+            </div>
+
+            <table class="table table-striped table-hover mb-0">
+                <thead>
+                <tr>
+                    <th>Kasir</th>
+                    <th>Perangkat</th>
+                    <th>Lokasi</th>
+                    <th>Modal Kas</th>
+                    <th>Total Penjualan</th>
+                    <th>Estimasi Kas</th>
+                    <th>Status</th>
+                    <th>Aktivitas Terakhir</th>
+                    <th>Ambang Kas</th>
+                </tr>
+                </thead>
+                <tbody>
+                @forelse($sessions as $session)
+                    <tr wire:key="session-{{ $session['id'] }}"
+                        @class(['table-warning' => $session['alerts']['idle'] || $session['alerts']['cash']])>
+                        <td class="align-middle">
+                            <div class="font-weight-bold">{{ $session['cashier'] }}</div>
+                            <div class="small text-muted">Mulai: {{ optional($session['started_at'])->format('d M Y H:i') }}</div>
+                        </td>
+                        <td class="align-middle">{{ $session['device'] }}</td>
+                        <td class="align-middle">{{ $session['location'] }}</td>
+                        <td class="align-middle">{{ format_currency($session['cash_float']) }}</td>
+                        <td class="align-middle">{{ format_currency($session['sales_total']) }}</td>
+                        <td class="align-middle font-weight-bold">{{ format_currency($session['estimated_cash']) }}</td>
+                        <td class="align-middle">
+                            @php
+                                $status = strtolower($session['status']);
+                                $statusClass = $status === 'active' ? 'success' : ($status === 'paused' ? 'warning' : 'secondary');
+                            @endphp
+                            <span class="badge badge-{{ $statusClass }}">{{ strtoupper($session['status']) }}</span>
+                            @if($session['alerts']['idle'])
+                                <span class="badge badge-warning">Idle</span>
+                            @endif
+                            @if($session['alerts']['cash'])
+                                <span class="badge badge-danger">Kas Tinggi</span>
+                            @endif
+                        </td>
+                        <td class="align-middle">
+                            <div class="small font-weight-bold">{{ $session['last_activity_for_humans'] }}</div>
+                            <div class="small text-muted">{{ $session['last_activity_at'] ?? 'Belum ada aktivitas' }}</div>
+                        </td>
+                        <td class="align-middle">
+                            @if($session['threshold'])
+                                {{ format_currency($session['threshold']) }}
+                            @else
+                                <span class="text-muted">Tidak diatur</span>
+                            @endif
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="9" class="text-center text-muted">Belum ada sesi POS untuk ditampilkan.</td>
+                    </tr>
+                @endforelse
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+@push('page_scripts')
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            window.addEventListener('pos-session-alert', function (event) {
+                const detail = event.detail || {};
+
+                if (typeof Swal === 'undefined') {
+                    return;
+                }
+
+                Swal.fire({
+                    toast: true,
+                    position: 'top-end',
+                    showConfirmButton: false,
+                    timer: 4000,
+                    timerProgressBar: true,
+                    icon: detail.type || 'info',
+                    title: detail.message || 'Ada peringatan sesi POS',
+                });
+            });
+        });
+    </script>
+@endpush


### PR DESCRIPTION
## Summary
- add a supervisor POS session monitor with live polling, alert toasts, and filtering
- expose idle-time and cash-threshold settings plus per-location overrides for alerting
- wire up navigation, routes, and migrations for the monitoring experience

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69246988f2848326ac0ab52af30c4d0a)