### PR TITLE
Add tenant-aware POS location resolution

### DIFF
--- a/Modules/Sale/Http/Controllers/PosController.php
+++ b/Modules/Sale/Http/Controllers/PosController.php
@@ -71,6 +71,7 @@ class PosController extends Controller
         $customer = Customer::findOrFail($request->customer_id);
 
         $validated = $request->validated();
+        PosLocationResolver::setActiveAssignment((int) data_get($validated, 'pos_location_assignment_id'));
         $paymentsInput = collect(data_get($validated, 'payments', []));
         $total_amount = round((float) data_get($validated, 'total_amount', 0), 2);
         $shippingAmount = round((float) data_get($validated, 'shipping_amount', 0), 2);

--- a/Modules/Sale/Http/Requests/StorePosSaleRequest.php
+++ b/Modules/Sale/Http/Requests/StorePosSaleRequest.php
@@ -26,7 +26,8 @@ class StorePosSaleRequest extends FormRequest
             'payments' => 'required|array|min:1',
             'payments.*.method_id' => 'required|integer',
             'payments.*.amount' => 'required|numeric|min:0',
-            'note' => 'nullable|string|max:1000'
+            'note' => 'nullable|string|max:1000',
+            'pos_location_assignment_id' => 'nullable|integer',
         ];
     }
 

--- a/Modules/Setting/Entities/Location.php
+++ b/Modules/Setting/Entities/Location.php
@@ -5,6 +5,8 @@ namespace Modules\Setting\Entities;
 use App\Models\BaseModel;
 use App\Support\PosLocationResolver;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Modules\Setting\Entities\SettingSaleLocation;
 
@@ -54,6 +56,18 @@ class Location extends BaseModel
     public function setting(): BelongsTo
     {
         return $this->belongsTo(Setting::class);
+    }
+
+    public function tenants(): BelongsToMany
+    {
+        return $this->belongsToMany(Setting::class, 'setting_sale_locations')
+            ->withPivot(['is_pos', 'position'])
+            ->withTimestamps();
+    }
+
+    public function saleAssignments(): HasMany
+    {
+        return $this->hasMany(SettingSaleLocation::class);
     }
 
     public function saleAssignment(): HasOne

--- a/Modules/Setting/Entities/SettingSaleLocation.php
+++ b/Modules/Setting/Entities/SettingSaleLocation.php
@@ -5,6 +5,8 @@ namespace Modules\Setting\Entities;
 use App\Models\BaseModel;
 use App\Support\PosLocationResolver;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class SettingSaleLocation extends BaseModel
 {
@@ -99,5 +101,15 @@ class SettingSaleLocation extends BaseModel
     public function location(): BelongsTo
     {
         return $this->belongsTo(Location::class);
+    }
+
+    public function scopeForSetting($query, ?int $settingId)
+    {
+        return $query->when($settingId, fn ($q) => $q->where('setting_id', $settingId));
+    }
+
+    public function scopeForLocation($query, ?int $locationId)
+    {
+        return $query->when($locationId, fn ($q) => $q->where('location_id', $locationId));
     }
 }


### PR DESCRIPTION
## Summary
- add tenant and assignment relationships on locations along with query scopes for sale-location pivot
- extend POS location resolver to store tenant-location assignment selections and fetch tenant options for a location
- accept tenant assignment identifier during POS sales to activate the selected tenant context

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69246ecd6fb483269423da1c4b776908)