### PR TITLE
Adjust pos session column placement in migration

### DIFF
--- a/database/migrations/2025_12_20_000100_add_pos_session_columns.php
+++ b/database/migrations/2025_12_20_000100_add_pos_session_columns.php
@@ -9,7 +9,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('sales', function (Blueprint $table) {
-            $table->foreignId('pos_session_id')->nullable()->after('location_id')->constrained('pos_sessions')->nullOnDelete();
+            $table->foreignId('pos_session_id')->nullable()->after('setting_id')->constrained('pos_sessions')->nullOnDelete();
         });
 
         Schema::table('sale_payments', function (Blueprint $table) {


### PR DESCRIPTION
## Summary
- update the sales pos_session_id column placement to avoid referencing a missing location column
- keep the down() migration dropping the constrained foreign key

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692475e4bc348326be6820b8745dae6c)