### PR TITLE
Add idempotency protection for create workflows

### DIFF
--- a/Modules/Product/Resources/views/products/create.blade.php
+++ b/Modules/Product/Resources/views/products/create.blade.php
@@ -6,6 +6,7 @@
     <div class="container-fluid">
         <form id="product-form" action="{{ route('products.store') }}" method="POST" enctype="multipart/form-data">
             @csrf
+            <input type="hidden" name="idempotency_token" value="{{ $idempotencyToken }}">
             <div class="row">
                 <div class="col-lg-12">
                     <div class="form-group">

--- a/Modules/Product/Routes/web.php
+++ b/Modules/Product/Routes/web.php
@@ -31,7 +31,7 @@ Route::group(['middleware' => ['auth', 'role.setting']], function () {
     Route::get('/products/search', [ProductController::class, 'search'])->name('products.search');
     Route::delete('/products/{product}/media/{media}', [ProductController::class, 'destroyMedia'])->name('products.media.destroy');
 
-    Route::resource('products', 'ProductController');
+    Route::resource('products', 'ProductController')->middleware('idempotency');
 
     Route::prefix('products/{product}/bundles')->group(function () {
         Route::get('/', [ProductBundleController::class, 'index'])->name('products.bundle.index');

--- a/Modules/Purchase/Resources/views/create.blade.php
+++ b/Modules/Purchase/Resources/views/create.blade.php
@@ -23,7 +23,7 @@
         <div class="row mt-4">
             <div class="col-md-12">
                 <div class="card">
-                    <livewire:purchase.create-form/>
+                    <livewire:purchase.create-form :idempotencyToken="$idempotencyToken" />
                 </div>
             </div>
         </div>

--- a/Modules/Purchase/Routes/web.php
+++ b/Modules/Purchase/Routes/web.php
@@ -57,7 +57,7 @@ Route::group(['middleware' => ['auth', 'role.setting']], function () {
     Route::post('/purchases/{purchase}/receive', [PurchaseController::class, 'storeReceive'])->name('purchases.storeReceive');
     Route::get('/purchases/{purchase}/receive', [PurchaseController::class, 'receive'])->name('purchases.receive');
     Route::patch('purchases/{purchase}/status', [PurchaseController::class, 'updateStatus'])->name('purchases.updateStatus');
-    Route::resource('purchases', 'PurchaseController');
+    Route::resource('purchases', 'PurchaseController')->middleware('idempotency');
 
     //Payments
     Route::get('/purchase-payments/datatable/{purchase_id}', [PurchasePaymentsController::class, 'datatable'])

--- a/Modules/Quotation/Http/Controllers/QuotationSalesController.php
+++ b/Modules/Quotation/Http/Controllers/QuotationSalesController.php
@@ -5,6 +5,7 @@ namespace Modules\Quotation\Http\Controllers;
 use Gloudemans\Shoppingcart\Facades\Cart;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
 use Modules\Product\Entities\Product;
 use Modules\Quotation\Entities\Quotation;
 
@@ -41,7 +42,8 @@ class QuotationSalesController extends Controller
 
         return view('quotation::quotation-sales.create', [
             'quotation_id' => $quotation->id,
-            'sale' => $quotation
+            'sale' => $quotation,
+            'idempotencyToken' => (string) Str::uuid(),
         ]);
     }
 }

--- a/Modules/Quotation/Resources/views/quotation-sales/create.blade.php
+++ b/Modules/Quotation/Resources/views/quotation-sales/create.blade.php
@@ -25,6 +25,7 @@
                         @include('utils.alerts')
                         <form id="sale-form" action="{{ route('sales.store') }}" method="POST">
                             @csrf
+                            <input type="hidden" name="idempotency_token" value="{{ $idempotencyToken }}">
 
                             <div class="form-row">
                                 <div class="col-lg-4">

--- a/Modules/Sale/Resources/views/create.blade.php
+++ b/Modules/Sale/Resources/views/create.blade.php
@@ -23,7 +23,7 @@
         <div class="row mt-4">
             <div class="col-md-12">
                 <div class="card">
-                    <livewire:sale.create-form/>
+                    <livewire:sale.create-form :idempotencyToken="$idempotencyToken" />
                 </div>
             </div>
         </div>

--- a/Modules/Sale/Routes/web.php
+++ b/Modules/Sale/Routes/web.php
@@ -63,7 +63,7 @@ Route::group(['middleware' => ['auth', 'role.setting']], function () {
     Route::post('/sales/{sale}/dispatch', [SaleController::class, 'storeDispatch'])->name('sales.storeDispatch');
     Route::get('/sales/{sale}/dispatch', [SaleController::class, 'dispatch'])->name('sales.dispatch');
     Route::patch('sales/{sale}/status', [SaleController::class, 'updateStatus'])->name('sales.updateStatus');
-    Route::resource('sales', 'SaleController');
+    Route::resource('sales', 'SaleController')->middleware('idempotency');
 
     //Payments
     Route::get('/sale-payments/{sale_id}', 'SalePaymentsController@index')->name('sale-payments.index');

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -66,5 +66,6 @@ class Kernel extends HttpKernel
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'role.setting' => \App\Http\Middleware\CheckUserRoleForSetting::class,
         'pos.session' => \App\Http\Middleware\EnsureActivePosSession::class,
+        'idempotency' => \App\Http\Middleware\IdempotencyMiddleware::class,
     ];
 }

--- a/app/Http/Middleware/IdempotencyMiddleware.php
+++ b/app/Http/Middleware/IdempotencyMiddleware.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Services\IdempotencyService;
+use Closure;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class IdempotencyMiddleware
+{
+    public function handle(Request $request, Closure $next)
+    {
+        if (! $request->isMethod('post') && ! $request->isMethod('put')) {
+            return $next($request);
+        }
+
+        $token = $request->header('X-Idempotency-Token') ?? $request->input('idempotency_token');
+        $routeName = $request->route()?->getName() ?? $request->path();
+        $userId = optional($request->user())->id;
+
+        if (! IdempotencyService::claim($token, $routeName, $userId)) {
+            return $this->reject($request);
+        }
+
+        return $next($request);
+    }
+
+    protected function reject(Request $request): RedirectResponse
+    {
+        return redirect()->back()->withInput()->withErrors([
+            'idempotency' => 'Permintaan yang sama sudah diproses. Silakan tunggu sebelum mencoba lagi.',
+        ]);
+    }
+}

--- a/app/Services/IdempotencyService.php
+++ b/app/Services/IdempotencyService.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Cache;
+
+class IdempotencyService
+{
+    private const CACHE_PREFIX = 'idempotency';
+    private const TTL_MINUTES = 5;
+
+    public static function claim(?string $token, string $routeName, $userId = null): bool
+    {
+        if (empty($token)) {
+            return false;
+        }
+
+        $key = sprintf('%s:%s:%s:%s', self::CACHE_PREFIX, $userId ?? 'guest', $routeName, $token);
+
+        return Cache::add($key, now()->toIso8601String(), now()->addMinutes(self::TTL_MINUTES));
+    }
+}

--- a/resources/views/livewire/purchase/create-form.blade.php
+++ b/resources/views/livewire/purchase/create-form.blade.php
@@ -1,5 +1,6 @@
 <div class="card-body">
     <form wire:submit.prevent="submit">
+        <input type="hidden" wire:model="idempotencyToken">
         <div class="form-row">
             <!-- Referensi -->
             <div class="col-lg-6 mb-3">

--- a/resources/views/livewire/sale/create-form.blade.php
+++ b/resources/views/livewire/sale/create-form.blade.php
@@ -1,5 +1,6 @@
 <div class="card-body">
     <form wire:submit.prevent="submit">
+        <input type="hidden" wire:model="idempotencyToken">
         <div class="form-row">
             <!-- Referensi -->
             <div class="col-lg-6 mb-3">

--- a/tests/Feature/ProductPriceCreationTest.php
+++ b/tests/Feature/ProductPriceCreationTest.php
@@ -70,7 +70,7 @@ class ProductPriceCreationTest extends TestCase
         ];
 
         $response = $this->withSession(['setting_id' => $activeSetting->id])
-            ->post(route('products.store'), $payload);
+            ->post(route('products.store'), $payload, ['X-Idempotency-Token' => 'test-product-price']);
 
         $response->assertRedirect(route('products.index'));
 

--- a/tests/Feature/ProductUnitConversionPriceTest.php
+++ b/tests/Feature/ProductUnitConversionPriceTest.php
@@ -99,7 +99,7 @@ class ProductUnitConversionPriceTest extends TestCase
         ];
 
         $response = $this->withSession(['setting_id' => $primarySetting->id])
-            ->post(route('products.store'), $payload);
+            ->post(route('products.store'), $payload, ['X-Idempotency-Token' => 'test-product-token']);
 
         $response->assertRedirect(route('products.index'));
 

--- a/tests/Feature/SaleMonetaryValuesTest.php
+++ b/tests/Feature/SaleMonetaryValuesTest.php
@@ -286,7 +286,7 @@ class SaleMonetaryValuesTest extends TestCase
             'payment_term_id' => $this->paymentTerm->id,
             'note' => 'Store decimals',
             'is_tax_included' => false,
-        ]);
+        ], ['X-Idempotency-Token' => uniqid('sale', true)]);
 
         $response->assertRedirect(route('sales.index'));
 
@@ -353,7 +353,7 @@ class SaleMonetaryValuesTest extends TestCase
             'payment_term_id' => $this->paymentTerm->id,
             'note' => 'Aggregate duplicates',
             'is_tax_included' => false,
-        ]);
+        ], ['X-Idempotency-Token' => uniqid('sale', true)]);
 
         $response->assertRedirect(route('sales.index'));
 
@@ -390,7 +390,7 @@ class SaleMonetaryValuesTest extends TestCase
             'payment_term_id' => $this->paymentTerm->id,
             'note' => 'Store bundle amounts',
             'is_tax_included' => false,
-        ]);
+        ], ['X-Idempotency-Token' => uniqid('sale', true)]);
 
         $response->assertRedirect(route('sales.index'));
 
@@ -612,7 +612,7 @@ class SaleMonetaryValuesTest extends TestCase
             'payment_term_id' => $this->paymentTerm->id,
             'note' => null,
             'is_tax_included' => false,
-        ])->assertRedirect(route('sales.index'));
+        ], ['X-Idempotency-Token' => uniqid('sale', true)])->assertRedirect(route('sales.index'));
 
         $sale = Sale::latest('id')->first();
         $this->assertNotNull($sale);


### PR DESCRIPTION
## Summary
- add shared idempotency service and middleware to guard POST/PUT submissions
- issue per-form idempotency tokens for product, sale, and purchase create flows (including quotation sales)
- update controllers, Livewire components, and tests to honor the one-time token checks

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c186c2e40832684ec947fa43ee516)