### PR TITLE
Add idempotency checks to store workflows

### DIFF
--- a/Modules/Adjustment/Resources/views/create-breakage.blade.php
+++ b/Modules/Adjustment/Resources/views/create-breakage.blade.php
@@ -19,6 +19,7 @@
                         @include('utils.alerts')
                         <form action="{{ route('adjustments.storeBreakage') }}" method="POST">
                             @csrf
+                            <input type="hidden" name="idempotency_token" value="{{ old('idempotency_token', $idempotencyToken) }}">
 
                             <div class="form-row">
                                 <div class="col-lg-6">

--- a/Modules/Adjustment/Resources/views/create.blade.php
+++ b/Modules/Adjustment/Resources/views/create.blade.php
@@ -11,6 +11,7 @@
                         @include('utils.alerts')
                         <form action="{{ route('adjustments.store') }}" method="POST">
                             @csrf
+                            <input type="hidden" name="idempotency_token" value="{{ old('idempotency_token', $idempotencyToken) }}">
 
                             <div class="form-row">
                                 <div class="col-lg-6">

--- a/Modules/Expense/Http/Controllers/ExpenseCategoriesController.php
+++ b/Modules/Expense/Http/Controllers/ExpenseCategoriesController.php
@@ -2,6 +2,7 @@
 
 namespace Modules\Expense\Http\Controllers;
 
+use App\Services\IdempotencyService;
 use Modules\Expense\DataTables\ExpenseCategoriesDataTable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Http\Request;
@@ -12,10 +13,17 @@ use Modules\Expense\Entities\ExpenseCategory;
 class ExpenseCategoriesController extends Controller
 {
 
-    public function index(ExpenseCategoriesDataTable $dataTable) {
+    public function __construct()
+    {
+        $this->middleware('idempotency')->only('store');
+    }
+
+    public function index(ExpenseCategoriesDataTable $dataTable, Request $request) {
         abort_if(Gate::denies('expenseCategories.access'), 403);
 
-        return $dataTable->render('expense::categories.index');
+        $idempotencyToken = IdempotencyService::tokenFromRequest($request);
+
+        return $dataTable->render('expense::categories.index', compact('idempotencyToken'));
     }
 
     public function store(Request $request) {

--- a/Modules/Expense/Http/Controllers/ExpenseController.php
+++ b/Modules/Expense/Http/Controllers/ExpenseController.php
@@ -2,6 +2,7 @@
 
 namespace Modules\Expense\Http\Controllers;
 
+use App\Services\IdempotencyService;
 use Modules\Expense\DataTables\ExpensesDataTable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Http\Request;
@@ -13,6 +14,11 @@ use PhpOffice\PhpSpreadsheet\Calculation\MathTrig\Exp;
 class ExpenseController extends Controller
 {
 
+    public function __construct()
+    {
+        $this->middleware('idempotency')->only('store');
+    }
+
     public function index(ExpensesDataTable $dataTable) {
         abort_if(Gate::denies('expenses.access'), 403);
 
@@ -20,10 +26,12 @@ class ExpenseController extends Controller
     }
 
 
-    public function create() {
+    public function create(Request $request) {
         abort_if(Gate::denies('expenses.create'), 403);
 
-        return view('expense::expenses.create');
+        $idempotencyToken = IdempotencyService::tokenFromRequest($request);
+
+        return view('expense::expenses.create', compact('idempotencyToken'));
     }
 
 

--- a/Modules/Expense/Resources/views/categories/index.blade.php
+++ b/Modules/Expense/Resources/views/categories/index.blade.php
@@ -49,6 +49,7 @@
                 </div>
                 <form action="{{ route('expense-categories.store') }}" method="POST">
                     @csrf
+                    <input type="hidden" name="idempotency_token" value="{{ old('idempotency_token', $idempotencyToken) }}">
                     <div class="modal-body">
                         <div class="form-group">
                             <label for="category_name">Nama Kategori <span class="text-danger">*</span></label>

--- a/Modules/Expense/Resources/views/expenses/create.blade.php
+++ b/Modules/Expense/Resources/views/expenses/create.blade.php
@@ -12,7 +12,7 @@
 
 @section('content')
     <div class="container-fluid">
-        <livewire:expense.expense-form />
+        <livewire:expense.expense-form :idempotencyToken="$idempotencyToken" />
     </div>
 @endsection
 

--- a/Modules/People/Http/Controllers/SuppliersController.php
+++ b/Modules/People/Http/Controllers/SuppliersController.php
@@ -2,6 +2,7 @@
 
 namespace Modules\People\Http\Controllers;
 
+use App\Services\IdempotencyService;
 use Modules\People\DataTables\SuppliersDataTable;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
@@ -13,6 +14,11 @@ use Modules\Purchase\Entities\PaymentTerm;
 class SuppliersController extends Controller
 {
 
+    public function __construct()
+    {
+        $this->middleware('idempotency')->only('store');
+    }
+
     public function index(SuppliersDataTable $dataTable)
     {
         abort_if(Gate::denies('suppliers.access'), 403);
@@ -21,14 +27,16 @@ class SuppliersController extends Controller
     }
 
 
-    public function create()
+    public function create(Request $request)
     {
         abort_if(Gate::denies('suppliers.create'), 403);
 
         // Ambil data PaymentTerm untuk dropdown
         $paymentTerms = PaymentTerm::all();
 
-        return view('people::suppliers.create', compact('paymentTerms'));
+        $idempotencyToken = IdempotencyService::tokenFromRequest($request);
+
+        return view('people::suppliers.create', compact('paymentTerms', 'idempotencyToken'));
     }
 
 

--- a/Modules/People/Resources/views/customers/create.blade.php
+++ b/Modules/People/Resources/views/customers/create.blade.php
@@ -14,6 +14,7 @@
     <div class="container-fluid">
         <form action="{{ route('customers.store') }}" method="POST">
             @csrf
+            <input type="hidden" name="idempotency_token" value="{{ old('idempotency_token', $idempotencyToken) }}">
             <div class="row">
                 <div class="col-lg-12">
                     <div class="form-group">

--- a/Modules/People/Resources/views/suppliers/create.blade.php
+++ b/Modules/People/Resources/views/suppliers/create.blade.php
@@ -14,6 +14,7 @@
     <div class="container-fluid">
         <form action="{{ route('suppliers.store') }}" method="POST">
             @csrf
+            <input type="hidden" name="idempotency_token" value="{{ old('idempotency_token', $idempotencyToken) }}">
             <div class="row">
                 <div class="col-lg-12">
                     <div class="form-group">

--- a/Modules/Product/Http/Controllers/ProductController.php
+++ b/Modules/Product/Http/Controllers/ProductController.php
@@ -2,7 +2,6 @@
 
 namespace Modules\Product\Http\Controllers;
 
-use App\Services\IdempotencyService;
 use Exception;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
@@ -234,12 +233,6 @@ class ProductController extends Controller
     public function store(StoreProductInfoRequest $request): RedirectResponse
     {
         abort_if(Gate::denies('products.create'), 403);
-        $token = $request->header('X-Idempotency-Token') ?? $request->input('idempotency_token');
-        if (! IdempotencyService::claim($token, 'products.store', optional($request->user())->id)) {
-            return redirect()->back()->withInput()->withErrors([
-                'idempotency' => 'Permintaan produk sudah diproses. Silakan tunggu sebelum mencoba lagi.',
-            ]);
-        }
         $validatedData = $request->validated();
 
         // Use the handleProductCreation method to create the product and get the product object

--- a/Modules/Purchase/Http/Controllers/PurchaseController.php
+++ b/Modules/Purchase/Http/Controllers/PurchaseController.php
@@ -2,7 +2,6 @@
 
 namespace Modules\Purchase\Http\Controllers;
 
-use App\Services\IdempotencyService;
 use Exception;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
@@ -83,12 +82,6 @@ class PurchaseController extends Controller
     public function store(StorePurchaseRequest $request): RedirectResponse
     {
         abort_if(Gate::denies('purchases.create'), 403);
-        $token = $request->header('X-Idempotency-Token') ?? $request->input('idempotency_token');
-        if (! IdempotencyService::claim($token, 'purchases.store', optional($request->user())->id)) {
-            return redirect()->back()->withInput()->withErrors([
-                'idempotency' => 'Permintaan pembelian sudah diproses. Silakan tunggu sebelum mencoba lagi.',
-            ]);
-        }
         if (Cart::instance('purchase')->count() == 0) {
             return redirect()->back()->withErrors(['cart' => 'Daftar Produk tidak boleh kosong.'])->withInput();
         }

--- a/Modules/Quotation/Http/Controllers/QuotationController.php
+++ b/Modules/Quotation/Http/Controllers/QuotationController.php
@@ -2,6 +2,7 @@
 
 namespace Modules\Quotation\Http\Controllers;
 
+use App\Services\IdempotencyService;
 use Gloudemans\Shoppingcart\Facades\Cart;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
@@ -18,6 +19,11 @@ use Modules\Quotation\Http\Requests\UpdateQuotationRequest;
 class QuotationController extends Controller
 {
 
+    public function __construct()
+    {
+        $this->middleware('idempotency')->only('store');
+    }
+
     public function index(QuotationsDataTable $dataTable) {
         abort_if(Gate::denies('quotations.access'), 403);
 
@@ -25,12 +31,14 @@ class QuotationController extends Controller
     }
 
 
-    public function create() {
+    public function create(Request $request) {
         abort_if(Gate::denies('create_quotations'), 403);
 
         Cart::instance('quotation')->destroy();
 
-        return view('quotation::create');
+        $idempotencyToken = IdempotencyService::tokenFromRequest($request);
+
+        return view('quotation::create', compact('idempotencyToken'));
     }
 
 

--- a/Modules/Quotation/Resources/views/create.blade.php
+++ b/Modules/Quotation/Resources/views/create.blade.php
@@ -25,6 +25,7 @@
                         @include('utils.alerts')
                         <form id="quotation-form" action="{{ route('quotations.store') }}" method="POST">
                             @csrf
+                            <input type="hidden" name="idempotency_token" value="{{ old('idempotency_token', $idempotencyToken) }}">
 
                             <div class="form-row">
                                 <div class="col-lg-4">

--- a/Modules/Sale/Http/Controllers/SaleController.php
+++ b/Modules/Sale/Http/Controllers/SaleController.php
@@ -2,7 +2,6 @@
 
 namespace Modules\Sale\Http\Controllers;
 
-use App\Services\IdempotencyService;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Exception;
 use Illuminate\Contracts\Foundation\Application;
@@ -70,12 +69,6 @@ class SaleController extends Controller
     public function store(StoreSaleRequest $request): RedirectResponse
     {
         abort_if(Gate::denies('sales.create'), 403);
-        $token = $request->header('X-Idempotency-Token') ?? $request->input('idempotency_token');
-        if (! IdempotencyService::claim($token, 'sales.store', optional($request->user())->id)) {
-            return redirect()->back()->withInput()->withErrors([
-                'idempotency' => 'Permintaan penjualan sudah dikirim. Mohon tunggu sebelum mencoba lagi.',
-            ]);
-        }
         Log::info('REQUEST', [
             'request' => $request->all(),
             'cart' => Cart::instance('sale')->content()->toArray()

--- a/Modules/Setting/Http/Controllers/PaymentTermController.php
+++ b/Modules/Setting/Http/Controllers/PaymentTermController.php
@@ -2,6 +2,7 @@
 
 namespace Modules\Setting\Http\Controllers;
 
+use App\Services\IdempotencyService;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Application;
@@ -13,6 +14,10 @@ use Modules\Purchase\Entities\PaymentTerm;
 
 class PaymentTermController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('idempotency')->only('store');
+    }
     /**
      * Display a listing of the resource.
      * @return Factory|Application|View|\Illuminate\Contracts\Foundation\Application
@@ -31,10 +36,12 @@ class PaymentTermController extends Controller
      * Show the form for creating a new resource.
      * @return Factory|Application|View|\Illuminate\Contracts\Foundation\Application
      */
-    public function create(): Factory|Application|View|\Illuminate\Contracts\Foundation\Application
+    public function create(Request $request): Factory|Application|View|\Illuminate\Contracts\Foundation\Application
     {
         abort_if(Gate::denies('paymentTerms.create'), 403);
-        return view('setting::payment_terms.create');
+        $idempotencyToken = IdempotencyService::tokenFromRequest($request);
+
+        return view('setting::payment_terms.create', compact('idempotencyToken'));
     }
 
     /**

--- a/Modules/Setting/Resources/views/payment_terms/create.blade.php
+++ b/Modules/Setting/Resources/views/payment_terms/create.blade.php
@@ -27,6 +27,7 @@
 
         <form action="{{ route('payment-terms.store') }}" method="POST">
             @csrf
+            <input type="hidden" name="idempotency_token" value="{{ old('idempotency_token', $idempotencyToken) }}">
             <div class="row">
                 <div class="col-lg-12">
                     <div class="card">

--- a/Modules/User/Http/Controllers/RolesController.php
+++ b/Modules/User/Http/Controllers/RolesController.php
@@ -2,6 +2,7 @@
 
 namespace Modules\User\Http\Controllers;
 
+use App\Services\IdempotencyService;
 use Modules\User\DataTables\RolesDataTable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Http\Request;
@@ -11,6 +12,10 @@ use Spatie\Permission\Models\Role;
 
 class RolesController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('idempotency')->only('store');
+    }
     public function index(RolesDataTable $dataTable) {
         abort_if(Gate::denies('roles.access'), 403);
 
@@ -18,10 +23,12 @@ class RolesController extends Controller
     }
 
 
-    public function create() {
+    public function create(Request $request) {
         abort_if(Gate::denies('roles.create'), 403);
 
-        return view('user::roles.create');
+        $idempotencyToken = IdempotencyService::tokenFromRequest($request);
+
+        return view('user::roles.create', compact('idempotencyToken'));
     }
 
 

--- a/Modules/User/Resources/views/roles/create.blade.php
+++ b/Modules/User/Resources/views/roles/create.blade.php
@@ -25,6 +25,7 @@
                 @include('utils.alerts')
                 <form action="{{ route('roles.store') }}" method="POST">
                     @csrf
+                    <input type="hidden" name="idempotency_token" value="{{ old('idempotency_token', $idempotencyToken) }}">
                     <div class="form-group mb-3 d-flex gap-2">
                         <button type="submit" class="btn btn-primary">Buat Peran <i class="bi bi-check"></i></button>
                         <a href="{{ route('roles.index') }}" class="btn btn-secondary">Kembali</a>

--- a/Modules/User/Resources/views/users/create.blade.php
+++ b/Modules/User/Resources/views/users/create.blade.php
@@ -24,6 +24,7 @@
     <div class="container-fluid mb-4">
         <form action="{{ route('users.store') }}" method="POST" enctype="multipart/form-data" id="user-form">
             @csrf
+            <input type="hidden" name="idempotency_token" value="{{ old('idempotency_token', $idempotencyToken) }}">
             <div class="row">
                 <div class="col-lg-12">
                     @include('utils.alerts')

--- a/app/Services/IdempotencyService.php
+++ b/app/Services/IdempotencyService.php
@@ -3,11 +3,18 @@
 namespace App\Services;
 
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 
 class IdempotencyService
 {
     private const CACHE_PREFIX = 'idempotency';
     private const TTL_MINUTES = 5;
+
+    public static function tokenFromRequest(Request $request): string
+    {
+        return $request->old('idempotency_token') ?? (string) Str::uuid();
+    }
 
     public static function claim(?string $token, string $routeName, $userId = null): bool
     {

--- a/resources/views/livewire/expense/expense-form.blade.php
+++ b/resources/views/livewire/expense/expense-form.blade.php
@@ -1,5 +1,6 @@
 <div>
     <form wire:submit.prevent="save" enctype="multipart/form-data">
+        <input type="hidden" wire:model="idempotencyToken">
         <div class="d-flex justify-content-end mb-3">
             <button class="btn btn-primary">
                 {{ $expenseId ? 'Ubah Biaya' : 'Simpan Biaya' }}


### PR DESCRIPTION
## Summary
- add an idempotency token helper and rely on the middleware to guard store actions before database writes
- apply idempotency middleware plus hidden tokens to store forms across expenses, people, adjustments/transfers, quotations, users/roles, and payment terms
- wire the expense Livewire form through the idempotency service and remove redundant controller-level claims to prevent double processing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c265315308326881b7db6266aeb90)