### PR TITLE
Add submit safeguards to create forms

### DIFF
--- a/Modules/People/Resources/views/customers/create.blade.php
+++ b/Modules/People/Resources/views/customers/create.blade.php
@@ -12,7 +12,7 @@
 
 @section('content')
     <div class="container-fluid">
-        <form action="{{ route('customers.store') }}" method="POST">
+        <form id="customer-create-form" action="{{ route('customers.store') }}" method="POST">
             @csrf
             <input type="hidden" name="idempotency_token" value="{{ old('idempotency_token', $idempotencyToken) }}">
             <div class="row">
@@ -22,7 +22,7 @@
                             Kembali
                         </a>
                         @can('customers.create')
-                        <button class="btn btn-primary">Tambahkan Pelanggan <i class="bi bi-check"></i></button>
+                        <button type="submit" class="btn btn-primary">Tambahkan Pelanggan <i class="bi bi-check"></i></button>
                         @endcan
                     </div>
                 </div>
@@ -167,3 +167,38 @@
         </form>
     </div>
 @endsection
+
+@push('page_scripts')
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const form = document.getElementById('customer-create-form');
+
+            if (!form) {
+                return;
+            }
+
+            const lockSubmitButtons = () => {
+                const submitButtons = form.querySelectorAll('button[type="submit"], input[type="submit"]');
+
+                submitButtons.forEach((button) => {
+                    if (button.dataset.locked === 'true') return;
+
+                    button.dataset.locked = 'true';
+                    button.disabled = true;
+
+                    if (button.tagName.toLowerCase() === 'button') {
+                        button.dataset.originalHtml = button.innerHTML;
+                        button.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span> Memproses...';
+                    } else {
+                        button.dataset.originalValue = button.value;
+                        button.value = 'Memproses...';
+                    }
+                });
+            };
+
+            form.addEventListener('submit', () => {
+                lockSubmitButtons();
+            }, { once: true });
+        });
+    </script>
+@endpush

--- a/Modules/People/Resources/views/suppliers/create.blade.php
+++ b/Modules/People/Resources/views/suppliers/create.blade.php
@@ -12,7 +12,7 @@
 
 @section('content')
     <div class="container-fluid">
-        <form action="{{ route('suppliers.store') }}" method="POST">
+        <form id="supplier-create-form" action="{{ route('suppliers.store') }}" method="POST">
             @csrf
             <input type="hidden" name="idempotency_token" value="{{ old('idempotency_token', $idempotencyToken) }}">
             <div class="row">
@@ -22,7 +22,7 @@
                             Kembali
                         </a>
                         @can('suppliers.create')
-                        <button class="btn btn-primary">Tambahkan Pemasok <i class="bi bi-check"></i></button>
+                        <button type="submit" class="btn btn-primary">Tambahkan Pemasok <i class="bi bi-check"></i></button>
                         @endcan
                     </div>
                 </div>
@@ -133,3 +133,38 @@
         </form>
     </div>
 @endsection
+
+@push('page_scripts')
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const form = document.getElementById('supplier-create-form');
+
+            if (!form) {
+                return;
+            }
+
+            const lockSubmitButtons = () => {
+                const submitButtons = form.querySelectorAll('button[type="submit"], input[type="submit"]');
+
+                submitButtons.forEach((button) => {
+                    if (button.dataset.locked === 'true') return;
+
+                    button.dataset.locked = 'true';
+                    button.disabled = true;
+
+                    if (button.tagName.toLowerCase() === 'button') {
+                        button.dataset.originalHtml = button.innerHTML;
+                        button.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span> Memproses...';
+                    } else {
+                        button.dataset.originalValue = button.value;
+                        button.value = 'Memproses...';
+                    }
+                });
+            };
+
+            form.addEventListener('submit', () => {
+                lockSubmitButtons();
+            }, { once: true });
+        });
+    </script>
+@endpush

--- a/resources/views/livewire/expense/expense-form.blade.php
+++ b/resources/views/livewire/expense/expense-form.blade.php
@@ -2,9 +2,20 @@
     <form wire:submit.prevent="save" enctype="multipart/form-data">
         <input type="hidden" wire:model="idempotencyToken">
         <div class="d-flex justify-content-end mb-3">
-            <button class="btn btn-primary">
-                {{ $expenseId ? 'Ubah Biaya' : 'Simpan Biaya' }}
-                <i class="bi bi-check"></i>
+            <button
+                type="submit"
+                class="btn btn-primary"
+                wire:loading.attr="disabled"
+                wire:target="save"
+            >
+                <span wire:loading.remove wire:target="save">
+                    {{ $expenseId ? 'Ubah Biaya' : 'Simpan Biaya' }}
+                    <i class="bi bi-check"></i>
+                </span>
+                <span wire:loading wire:target="save">
+                    <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+                    Memproses...
+                </span>
             </button>
         </div>
 
@@ -153,8 +164,19 @@
         </div>
 
         <div class="form-group">
-            <button class="btn btn-success">
-                {{ $expenseId ? 'Perbarui' : 'Simpan' }}
+            <button
+                type="submit"
+                class="btn btn-success"
+                wire:loading.attr="disabled"
+                wire:target="save"
+            >
+                <span wire:loading.remove wire:target="save">
+                    {{ $expenseId ? 'Perbarui' : 'Simpan' }}
+                </span>
+                <span wire:loading wire:target="save">
+                    <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+                    Memproses...
+                </span>
             </button>
         </div>
     </form>


### PR DESCRIPTION
## Summary
- add wire loading states and spinners to expense create form submits
- lock customer and supplier create form submit buttons with processing indicators to prevent duplicate submissions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c4093664083269991dc5bb3e3ee7b)