### PR TITLE
Add supplier purchase number to purchases

### DIFF
--- a/Modules/Purchase/Database/Migrations/2025_09_10_000500_add_supplier_purchase_number_to_purchases_table.php
+++ b/Modules/Purchase/Database/Migrations/2025_09_10_000500_add_supplier_purchase_number_to_purchases_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('purchases', function (Blueprint $table) {
+            $table->string('supplier_purchase_number')
+                ->nullable()
+                ->after('supplier_reference_no');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('purchases', function (Blueprint $table) {
+            $table->dropColumn('supplier_purchase_number');
+        });
+    }
+};

--- a/Modules/Purchase/Entities/Purchase.php
+++ b/Modules/Purchase/Entities/Purchase.php
@@ -20,6 +20,7 @@ class Purchase extends BaseModel
         'due_date',
         'reference',
         'supplier_id',
+        'supplier_purchase_number',
         'tax_id',
         'tax_percentage',
         'tax_amount',

--- a/Modules/Purchase/Http/Controllers/PurchaseController.php
+++ b/Modules/Purchase/Http/Controllers/PurchaseController.php
@@ -94,6 +94,7 @@ class PurchaseController extends Controller
                 'date' => $request->date,
                 'due_date' => $request->due_date,
                 'supplier_id' => $request->supplier_id,
+                'supplier_purchase_number' => $request->supplier_purchase_number,
                 'tax_id' => $request->tax_id,
                 'tax_percentage' => 0, // Example
                 'tax_amount' => 0, // Example
@@ -251,6 +252,7 @@ class PurchaseController extends Controller
                 'date' => $request->filled('date') && $request->date !== $purchase->date ? $request->date : null,
                 'due_date' => $request->filled('due_date') && $request->due_date !== $purchase->due_date ? $request->due_date : null,
                 'supplier_id' => $request->filled('supplier_id') && $request->supplier_id !== $purchase->supplier_id ? $request->supplier_id : null,
+                'supplier_purchase_number' => $request->filled('supplier_purchase_number') && $request->supplier_purchase_number !== $purchase->supplier_purchase_number ? $request->supplier_purchase_number : null,
                 'tax_percentage' => $request->filled('tax_percentage') && $request->tax_percentage !== $purchase->tax_percentage ? $request->tax_percentage : null,
                 'discount_percentage' => $request->filled('discount_percentage') && $request->discount_percentage !== $purchase->discount_percentage ? $request->discount_percentage : null,
                 'shipping_amount' => $request->filled('shipping_amount') && $request->shipping_amount != $purchase->shipping_amount ? $request->shipping_amount : null,

--- a/Modules/Purchase/Http/Requests/StorePurchaseRequest.php
+++ b/Modules/Purchase/Http/Requests/StorePurchaseRequest.php
@@ -17,6 +17,7 @@ class StorePurchaseRequest extends FormRequest
         return [
             'supplier_id' => 'required|integer|exists:suppliers,id',
             'reference' => 'required|string|max:255',
+            'supplier_purchase_number' => 'nullable|string|max:255',
             'date' => 'required|date',
             'due_date' => 'required|date|after_or_equal:date',
             'tax_id' => 'nullable|integer|exists:taxes,id',

--- a/Modules/Purchase/Http/Requests/UpdatePurchaseRequest.php
+++ b/Modules/Purchase/Http/Requests/UpdatePurchaseRequest.php
@@ -17,6 +17,7 @@ class UpdatePurchaseRequest extends FormRequest
         return [
             'supplier_id' => 'required|integer|exists:suppliers,id',
             'reference' => 'required|string|max:255',
+            'supplier_purchase_number' => 'nullable|string|max:255',
             'date' => 'required|date',
             'due_date' => 'required|date|after_or_equal:date',
             'tax_id' => 'nullable|integer|exists:taxes,id',

--- a/app/Livewire/Purchase/CreateForm.php
+++ b/app/Livewire/Purchase/CreateForm.php
@@ -22,6 +22,7 @@ class CreateForm extends Component
     public $reference;
     public $supplier_id;
     public $supplier_name; // To sync with SupplierLoader
+    public $supplier_purchase_number;
     public $date;
     public $due_date;
     public $payment_term;
@@ -50,6 +51,7 @@ class CreateForm extends Component
         $this->date = now()->format('Y-m-d');
         $this->due_date = now()->format('Y-m-d');
         $this->paymentTerms = PaymentTerm::all();
+        $this->supplier_purchase_number = '';
     }
 
     public function updatedSupplierId($value): void
@@ -124,6 +126,7 @@ class CreateForm extends Component
     {
         $this->validate([
             'supplier_id' => 'required|exists:suppliers,id',
+            'supplier_purchase_number' => 'nullable|string|max:255',
             'date' => 'required|date',
             'due_date' => 'required|date|after_or_equal:date',
             'payment_term' => 'required|exists:payment_terms,id',
@@ -183,6 +186,7 @@ class CreateForm extends Component
                 'date' => $this->date,
                 'due_date' => $this->due_date,
                 'supplier_id' => $this->supplier_id,
+                'supplier_purchase_number' => $this->supplier_purchase_number,
                 'discount_percentage' => $discount_percentage,
                 'discount_amount' => $discount_amount,
                 'shipping_amount' => $shipping,

--- a/app/Livewire/Purchase/EditForm.php
+++ b/app/Livewire/Purchase/EditForm.php
@@ -21,6 +21,7 @@ class EditForm extends Component
     public $reference;
     public $supplier_id;
     public $supplier_name;
+    public $supplier_purchase_number;
     public $date;
     public $due_date;
     public $payment_term;
@@ -50,6 +51,7 @@ class EditForm extends Component
 
         $this->reference = $this->purchase->reference;
         $this->supplier_id = $this->purchase->supplier_id;
+        $this->supplier_purchase_number = $this->purchase->supplier_purchase_number;
         $this->date = $this->purchase->date;
         $this->due_date = $this->purchase->due_date;
         $this->payment_term = $this->purchase->payment_term_id;
@@ -111,6 +113,7 @@ class EditForm extends Component
     {
         $this->validate([
             'supplier_id' => 'required|exists:suppliers,id',
+            'supplier_purchase_number' => 'nullable|string|max:255',
             'date' => 'required|date',
             'due_date' => 'required|date|after_or_equal:date',
             'payment_term' => 'required|exists:payment_terms,id',
@@ -167,6 +170,7 @@ class EditForm extends Component
                     'due_amount' => $total_amount,
                     'is_tax_included' => $this->is_tax_included,
                     'supplier_id' => $this->supplier_id !== $purchase->supplier_id ? $this->supplier_id : null,
+                    'supplier_purchase_number' => $this->supplier_purchase_number !== $purchase->supplier_purchase_number ? $this->supplier_purchase_number : null,
                     'note' => $this->note !== $purchase->note ? $this->note : null,
                     'payment_term_id' => $this->payment_term !== $purchase->payment_term_id ? $this->payment_term : null,
                 ], fn($value) => !is_null($value));

--- a/resources/views/livewire/purchase/create-form.blade.php
+++ b/resources/views/livewire/purchase/create-form.blade.php
@@ -16,6 +16,13 @@
                 <div class="text-danger">{{ $message }}</div> @enderror
             </div>
 
+            <div class="col-lg-6 mb-3">
+                <label for="supplier_purchase_number">Nomor Pembelian Pemasok</label>
+                <input type="text" class="form-control" id="supplier_purchase_number" wire:model="supplier_purchase_number">
+                @error('supplier_purchase_number')
+                <div class="text-danger">{{ $message }}</div> @enderror
+            </div>
+
             <!-- Tanggal -->
             <div class="col-lg-6 mb-3">
                 <label for="date">Tanggal <span class="text-danger">*</span></label>

--- a/resources/views/livewire/purchase/edit-form.blade.php
+++ b/resources/views/livewire/purchase/edit-form.blade.php
@@ -14,6 +14,13 @@
             </div>
 
             <div class="col-lg-6 mb-3">
+                <label>Nomor Pembelian Pemasok</label>
+                <input type="text" class="form-control" wire:model="supplier_purchase_number">
+                @error('supplier_purchase_number')
+                <div class="text-danger">{{ $message }}</div> @enderror
+            </div>
+
+            <div class="col-lg-6 mb-3">
                 <label>Tanggal</label>
                 <input type="date" class="form-control" wire:model="date">
                 @error('date')


### PR DESCRIPTION
## Summary
- add a migration to store a nullable supplier purchase number on purchases
- expose the new attribute through the Purchase model, validation, and creation/update flows
- surface supplier purchase number inputs in the purchase Livewire create and edit forms

## Testing
- php artisan test --testsuite=Feature --stop-on-failure *(fails: vendor/autoload.php missing)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c51bb73208326a630945b9663c02c)