### PR TITLE
Add supplier purchase number support to Livewire purchase forms

### DIFF
--- a/app/Livewire/Purchase/CreateForm.php
+++ b/app/Livewire/Purchase/CreateForm.php
@@ -51,7 +51,7 @@ class CreateForm extends Component
         $this->date = now()->format('Y-m-d');
         $this->due_date = now()->format('Y-m-d');
         $this->paymentTerms = PaymentTerm::all();
-        $this->supplier_purchase_number = '';
+        $this->supplier_purchase_number = null;
     }
 
     public function updatedSupplierId($value): void
@@ -186,7 +186,7 @@ class CreateForm extends Component
                 'date' => $this->date,
                 'due_date' => $this->due_date,
                 'supplier_id' => $this->supplier_id,
-                'supplier_purchase_number' => $this->supplier_purchase_number,
+                'supplier_purchase_number' => $this->supplier_purchase_number ?: null,
                 'discount_percentage' => $discount_percentage,
                 'discount_amount' => $discount_amount,
                 'shipping_amount' => $shipping,

--- a/app/Livewire/Purchase/EditForm.php
+++ b/app/Livewire/Purchase/EditForm.php
@@ -159,6 +159,8 @@ class EditForm extends Component
 
                 $total_amount = $total_sub_total - $global_discount_amount + $shipping;
 
+                $supplierPurchaseNumber = $this->supplier_purchase_number ?: null;
+
                 $updateData = array_filter([
                     'date' => $this->date !== $purchase->date ? $this->date : null,
                     'due_date' => $this->due_date !== $purchase->due_date ? $this->due_date : null,
@@ -170,7 +172,7 @@ class EditForm extends Component
                     'due_amount' => $total_amount,
                     'is_tax_included' => $this->is_tax_included,
                     'supplier_id' => $this->supplier_id !== $purchase->supplier_id ? $this->supplier_id : null,
-                    'supplier_purchase_number' => $this->supplier_purchase_number !== $purchase->supplier_purchase_number ? $this->supplier_purchase_number : null,
+                    'supplier_purchase_number' => $supplierPurchaseNumber !== $purchase->supplier_purchase_number ? $supplierPurchaseNumber : null,
                     'note' => $this->note !== $purchase->note ? $this->note : null,
                     'payment_term_id' => $this->payment_term !== $purchase->payment_term_id ? $this->payment_term : null,
                 ], fn($value) => !is_null($value));

--- a/resources/views/livewire/purchase/create-form.blade.php
+++ b/resources/views/livewire/purchase/create-form.blade.php
@@ -17,8 +17,8 @@
             </div>
 
             <div class="col-lg-6 mb-3">
-                <label for="supplier_purchase_number">Nomor Pembelian Pemasok</label>
-                <input type="text" class="form-control" id="supplier_purchase_number" wire:model="supplier_purchase_number">
+                <label for="supplier_purchase_number">Nomor Pembelian Supplier</label>
+                <input type="text" class="form-control" id="supplier_purchase_number" wire:model="supplier_purchase_number" placeholder="Opsional">
                 @error('supplier_purchase_number')
                 <div class="text-danger">{{ $message }}</div> @enderror
             </div>

--- a/resources/views/livewire/purchase/edit-form.blade.php
+++ b/resources/views/livewire/purchase/edit-form.blade.php
@@ -14,8 +14,8 @@
             </div>
 
             <div class="col-lg-6 mb-3">
-                <label>Nomor Pembelian Pemasok</label>
-                <input type="text" class="form-control" wire:model="supplier_purchase_number">
+                <label>Nomor Pembelian Supplier</label>
+                <input type="text" class="form-control" wire:model="supplier_purchase_number" placeholder="Opsional">
                 @error('supplier_purchase_number')
                 <div class="text-danger">{{ $message }}</div> @enderror
             </div>


### PR DESCRIPTION
## Summary
- allow Livewire purchase create/edit forms to capture optional supplier purchase numbers and persist them
- hydrate supplier purchase number when editing and normalize empty values to null
- update purchase Blade forms to show an optional "Nomor Pembelian Supplier" input

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c53b835b483268cf3fb7066bfd7ef)