### PR TITLE
Add supplier purchase number column to purchase tables

### DIFF
--- a/Modules/Purchase/DataTables/PurchaseDataTable.php
+++ b/Modules/Purchase/DataTables/PurchaseDataTable.php
@@ -86,6 +86,7 @@ class PurchaseDataTable extends DataTable
         if ($search = $this->request()->get('search')['value'] ?? null) {
             $query->where(function ($q) use ($search) {
                 $q->where('reference', 'like', "%{$search}%")
+                    ->orWhere('supplier_purchase_number', 'like', "%{$search}%")
                     ->orWhereHas('supplier', function ($q) use ($search) {
                         $q->where('supplier_name', 'like', "%{$search}%");
                     })
@@ -114,7 +115,7 @@ class PurchaseDataTable extends DataTable
             ->dom("<'row'<'col-md-3'l><'col-md-5 mb-2'B><'col-md-4'f>> .
                                 'tr' .
                                 <'row'<'col-md-5'i><'col-md-7 mt-2'p>>")
-            ->orderBy(11)
+            ->orderBy(12)
             ->buttons(
                 Button::make('excel')
                     ->text('<i class="bi bi-file-earmark-excel-fill"></i> Excel'),
@@ -137,6 +138,10 @@ class PurchaseDataTable extends DataTable
 
             Column::make('reference_hyperlink')
                 ->title('Referensi')
+                ->className('text-center align-middle'),
+
+            Column::make('supplier_purchase_number')
+                ->title('Nomor Pembelian Supplier')
                 ->className('text-center align-middle'),
 
             Column::make('supplier.supplier_name')

--- a/app/Livewire/Purchase/PurchaseTable.php
+++ b/app/Livewire/Purchase/PurchaseTable.php
@@ -72,6 +72,7 @@ class PurchaseTable extends Component
                 $q->where(function ($qq) {
                     $search = $this->search;
                     $qq->where('reference', 'like', "%{$search}%")
+                        ->orWhere('supplier_purchase_number', 'like', "%{$search}%")
                         ->orWhereHas('supplier', function ($q2) use ($search) {
                             $q2->where('supplier_name', 'like', "%{$search}%");
                         })

--- a/resources/views/livewire/purchase/purchase-table.blade.php
+++ b/resources/views/livewire/purchase/purchase-table.blade.php
@@ -6,7 +6,7 @@
         <form class="d-flex" wire:submit.prevent="searchSubmit" style="gap: 0.5rem;">
             <input type="text"
                    class="form-control"
-                   placeholder="Cari referensi, pemasok, tag..."
+                   placeholder="Cari referensi, nomor pembelian supplier, pemasok, tag..."
                    wire:model.defer="searchText"
                    style="width: 220px;"
                    autocomplete="off"
@@ -27,6 +27,9 @@
         <tr>
             <th wire:click="sortBy('reference')" style="cursor:pointer">
                 Ref {!! $this->sortIcon('reference') !!}
+            </th>
+            <th wire:click="sortBy('supplier_purchase_number')" style="cursor:pointer">
+                Nomor Pembelian Supplier {!! $this->sortIcon('supplier_purchase_number') !!}
             </th>
             <th wire:click="sortBy('date')" style="cursor:pointer">
                 Tanggal {!! $this->sortIcon('date') !!}
@@ -50,6 +53,7 @@
                         {{ $purchase->reference }}
                     </a>
                 </td>
+                <td>{{ $purchase->supplier_purchase_number ?? '-' }}</td>
                 <td>
                     {{ Carbon::parse($purchase->date)->format('d M Y') }}
                 </td>
@@ -68,7 +72,7 @@
             </tr>
         @empty
             <tr>
-                <td colspan="8">Tidak ada data yang ditemukan.</td>
+                <td colspan="9">Tidak ada data yang ditemukan.</td>
             </tr>
         @endforelse
         </tbody>


### PR DESCRIPTION
## Summary
- add supplier purchase number display column to the purchase DataTable configuration and include it in the default ordering
- extend Livewire purchase table to show and sort by the supplier purchase number while updating search to cover the new field for both listings

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c57b1525083269c118f8670b5f09b)