### PR TITLE
Add inline supplier purchase number editor

### DIFF
--- a/Modules/Purchase/Resources/views/show.blade.php
+++ b/Modules/Purchase/Resources/views/show.blade.php
@@ -55,6 +55,12 @@
                                 <h5 class="mb-2 border-bottom pb-2">Info Faktur:</h5>
                                 <div>Faktur: <strong>INV/{{ $purchase->reference }}</strong></div>
                                 <div>Tanggal: {{ \Carbon\Carbon::parse($purchase->date)->format('d M, Y') }}</div>
+                                <div class="mt-2">
+                                    <livewire:purchase.supplier-purchase-number-editor
+                                        :purchaseId="$purchase->id"
+                                        :key="'supplier-purchase-number-' . $purchase->id"
+                                    />
+                                </div>
                                 <div>
                                     Status: <strong>{{ $purchase->status }}</strong>
                                 </div>

--- a/app/Livewire/Purchase/SupplierPurchaseNumberEditor.php
+++ b/app/Livewire/Purchase/SupplierPurchaseNumberEditor.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Livewire\Purchase;
+
+use Illuminate\Support\Facades\Gate;
+use Livewire\Component;
+use Modules\Purchase\Entities\Purchase;
+
+class SupplierPurchaseNumberEditor extends Component
+{
+    public int $purchaseId;
+    public ?string $supplierPurchaseNumber = null;
+    public bool $editing = false;
+    public bool $canEdit = false;
+
+    public function mount(int $purchaseId): void
+    {
+        $purchase = Purchase::findOrFail($purchaseId);
+        $this->ensurePurchaseBelongsToCurrentSetting($purchase);
+
+        $this->purchaseId = $purchaseId;
+        $this->supplierPurchaseNumber = $purchase->supplier_purchase_number;
+        $this->canEdit = Gate::allows('purchases.edit');
+    }
+
+    public function startEditing(): void
+    {
+        $this->authorizeEdit();
+        $this->editing = true;
+    }
+
+    public function cancelEdit(): void
+    {
+        $purchase = $this->findPurchase();
+        $this->supplierPurchaseNumber = $purchase->supplier_purchase_number;
+        $this->editing = false;
+    }
+
+    public function save(): void
+    {
+        $this->authorizeEdit();
+
+        $data = $this->validate([
+            'supplierPurchaseNumber' => 'nullable|string|max:255',
+        ]);
+
+        $purchase = $this->findPurchase();
+        $value = $data['supplierPurchaseNumber'];
+        $normalizedValue = $value === '' ? null : $value;
+
+        $purchase->update([
+            'supplier_purchase_number' => $normalizedValue,
+        ]);
+
+        $this->supplierPurchaseNumber = $purchase->supplier_purchase_number;
+        $this->editing = false;
+
+        $this->dispatch('notify', ['type' => 'success', 'message' => 'Nomor pembelian pemasok diperbarui.']);
+    }
+
+    public function render()
+    {
+        return view('livewire.purchase.supplier-purchase-number-editor');
+    }
+
+    private function authorizeEdit(): void
+    {
+        abort_if(Gate::denies('purchases.edit'), 403);
+    }
+
+    private function findPurchase(): Purchase
+    {
+        $purchase = Purchase::findOrFail($this->purchaseId);
+        $this->ensurePurchaseBelongsToCurrentSetting($purchase);
+
+        return $purchase;
+    }
+
+    private function ensurePurchaseBelongsToCurrentSetting(Purchase $purchase): void
+    {
+        $currentSettingId = session('setting_id');
+
+        if (! is_null($currentSettingId) && (int) $purchase->setting_id !== (int) $currentSettingId) {
+            abort(404);
+        }
+    }
+}

--- a/resources/views/livewire/purchase/supplier-purchase-number-editor.blade.php
+++ b/resources/views/livewire/purchase/supplier-purchase-number-editor.blade.php
@@ -1,0 +1,38 @@
+<div>
+    <div class="d-flex align-items-start mb-2">
+        <div class="flex-grow-1">
+            <div>Nomor Pembelian Supplier:</div>
+            <div class="fw-semibold">{{ $supplierPurchaseNumber ?: '-' }}</div>
+        </div>
+
+        @if($canEdit && ! $editing)
+            <button type="button"
+                    class="btn btn-link btn-sm text-decoration-none"
+                    wire:click="startEditing"
+                    wire:loading.attr="disabled">
+                <i class="bi bi-pencil"></i> Ubah
+            </button>
+        @endif
+    </div>
+
+    @if ($editing)
+        <div class="border rounded p-2 bg-light">
+            <label for="supplier_purchase_number" class="form-label mb-1">Perbarui Nomor Pembelian Supplier</label>
+            <input id="supplier_purchase_number" type="text" class="form-control form-control-sm"
+                   wire:model.defer="supplierPurchaseNumber"
+                   placeholder="Opsional" />
+            @error('supplierPurchaseNumber')
+                <div class="text-danger small mt-1">{{ $message }}</div>
+            @enderror
+
+            <div class="mt-2 d-flex align-items-center">
+                <button class="btn btn-primary btn-sm" type="button" wire:click="save" wire:loading.attr="disabled">
+                    Simpan
+                </button>
+                <button class="btn btn-secondary btn-sm ms-2" type="button" wire:click="cancelEdit" wire:loading.attr="disabled">
+                    Batal
+                </button>
+            </div>
+        </div>
+    @endif
+</div>


### PR DESCRIPTION
## Summary
- add a Livewire component to manage inline edits to a purchase's supplier purchase number with authorization and setting checks
- render the supplier purchase number with edit controls on the purchase detail page and persist updates without touching other fields

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c5c3b22448326a07a8c58bc13e5a3)