### PR TITLE
Allow nullable supplier purchase numbers

### DIFF
--- a/Modules/Purchase/Http/Controllers/PurchaseController.php
+++ b/Modules/Purchase/Http/Controllers/PurchaseController.php
@@ -252,7 +252,6 @@ class PurchaseController extends Controller
                 'date' => $request->filled('date') && $request->date !== $purchase->date ? $request->date : null,
                 'due_date' => $request->filled('due_date') && $request->due_date !== $purchase->due_date ? $request->due_date : null,
                 'supplier_id' => $request->filled('supplier_id') && $request->supplier_id !== $purchase->supplier_id ? $request->supplier_id : null,
-                'supplier_purchase_number' => $request->filled('supplier_purchase_number') && $request->supplier_purchase_number !== $purchase->supplier_purchase_number ? $request->supplier_purchase_number : null,
                 'tax_percentage' => $request->filled('tax_percentage') && $request->tax_percentage !== $purchase->tax_percentage ? $request->tax_percentage : null,
                 'discount_percentage' => $request->filled('discount_percentage') && $request->discount_percentage !== $purchase->discount_percentage ? $request->discount_percentage : null,
                 'shipping_amount' => $request->filled('shipping_amount') && $request->shipping_amount != $purchase->shipping_amount ? $request->shipping_amount : null,
@@ -265,6 +264,10 @@ class PurchaseController extends Controller
             ], function ($value) {
                 return $value !== null;
             });
+
+            if ($request->has('supplier_purchase_number') && $request->supplier_purchase_number !== $purchase->supplier_purchase_number) {
+                $updateData['supplier_purchase_number'] = $request->supplier_purchase_number;
+            }
 
             if (!empty($updateData)) {
                 // Update the purchase record

--- a/Modules/Purchase/Http/Requests/StorePurchaseRequest.php
+++ b/Modules/Purchase/Http/Requests/StorePurchaseRequest.php
@@ -17,7 +17,7 @@ class StorePurchaseRequest extends FormRequest
         return [
             'supplier_id' => 'required|integer|exists:suppliers,id',
             'reference' => 'required|string|max:255',
-            'supplier_purchase_number' => 'nullable|string|max:255',
+            'supplier_purchase_number' => 'sometimes|nullable|string|max:255',
             'date' => 'required|date',
             'due_date' => 'required|date|after_or_equal:date',
             'tax_id' => 'nullable|integer|exists:taxes,id',

--- a/Modules/Purchase/Http/Requests/UpdatePurchaseRequest.php
+++ b/Modules/Purchase/Http/Requests/UpdatePurchaseRequest.php
@@ -17,7 +17,7 @@ class UpdatePurchaseRequest extends FormRequest
         return [
             'supplier_id' => 'required|integer|exists:suppliers,id',
             'reference' => 'required|string|max:255',
-            'supplier_purchase_number' => 'nullable|string|max:255',
+            'supplier_purchase_number' => 'sometimes|nullable|string|max:255',
             'date' => 'required|date',
             'due_date' => 'required|date|after_or_equal:date',
             'tax_id' => 'nullable|integer|exists:taxes,id',


### PR DESCRIPTION
## Summary
- allow nullable supplier_purchase_number in purchase store/update request validation
- ensure non-Livewire controller updates propagate supplier_purchase_number changes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c5df462e48326838729b5bde4f554)