### PR TITLE
Handle masked cash payments in checkout calculations

### DIFF
--- a/app/Livewire/Pos/Checkout.php
+++ b/app/Livewire/Pos/Checkout.php
@@ -230,11 +230,17 @@ class Checkout extends Component
     {
         return collect($this->payments)
             ->contains(function ($payment) {
-                if (! $this->paymentMethodIsCash((int) data_get($payment, 'method_id'))) {
+                $methodId = data_get($payment, 'method_id');
+
+                if ($methodId === null || $methodId === '') {
                     return false;
                 }
 
-                return (float) data_get($payment, 'amount', 0) > 0;
+                if (! $this->paymentMethodIsCash((int) $methodId)) {
+                    return false;
+                }
+
+                return $this->sanitizeCurrencyValue(data_get($payment, 'amount', 0)) > 0;
             });
     }
 

--- a/resources/views/livewire/pos/includes/checkout-modal.blade.php
+++ b/resources/views/livewire/pos/includes/checkout-modal.blade.php
@@ -129,7 +129,7 @@
                                                                 id="payment-method-{{ $payment['uuid'] ?? $index }}"
                                                                 class="form-control"
                                                                 name="payments[{{ $index }}][method_id]"
-                                                                wire:model="payments.{{ $index }}.method_id"
+                                                                wire:model.live="payments.{{ $index }}.method_id"
                                                                 required>
                                                                 <option value="">-- Pilih Metode --</option>
                                                                 @foreach($paymentMethods as $method)

--- a/tests/Feature/PosCheckoutTest.php
+++ b/tests/Feature/PosCheckoutTest.php
@@ -190,6 +190,29 @@ class PosCheckoutTest extends TestCase
             ->assertSet('overPaidWithNonCash', false);
     }
 
+    public function test_checkout_component_detects_cash_overpayment_with_masked_values(): void
+    {
+        $cashMethod = PaymentMethod::create([
+            'name' => 'Cash',
+            'coa_id' => $this->chartOfAccount->id,
+            'is_cash' => true,
+            'is_available_in_pos' => true,
+        ]);
+
+        $component = Livewire::test(Checkout::class, [
+            'cartInstance' => 'sale',
+            'customers' => Customer::all(),
+        ]);
+
+        $component
+            ->set('payments.0.method_id', (string) $cashMethod->id)
+            ->set('total_amount', '55000')
+            ->set('payments.0.amount', '100.000')
+            ->assertSet('hasCashPayment', true)
+            ->assertSet('overPaidWithNonCash', false)
+            ->assertSet('changeDue', 45000.0);
+    }
+
     public function test_change_modal_displays_formatted_rupiah_when_change_positive(): void
     {
         $cashMethod = PaymentMethod::create([


### PR DESCRIPTION
## Summary
- ensure checkout payment method and amount inputs stay in sync with Livewire state
- sanitize masked cash entries when determining change so overpayments are recognized
- add regression coverage for formatted cash overpayment values

## Testing
- Not run (dependency installation blocked by PHP version constraints)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c62491880832690d61c1f548b6d87)