### PR TITLE
Update POS payment formatter for live input sync

### DIFF
--- a/Modules/Sale/Resources/views/pos/index.blade.php
+++ b/Modules/Sale/Resources/views/pos/index.blade.php
@@ -277,6 +277,11 @@
                     }
                 };
 
+                const handleLiveUpdate = () => {
+                    display.dataset.posCurrencyEditing = 'true';
+                    updateHiddenField();
+                };
+
                 display.addEventListener('blur', () => {
                     display.dataset.posCurrencyEditing = 'false';
                     updateHiddenField();
@@ -292,6 +297,9 @@
                         display.blur();
                     }
                 });
+
+                display.addEventListener('input', handleLiveUpdate);
+                display.addEventListener('keyup', handleLiveUpdate);
             };
 
             window.initPosCurrencyFormatter = function () {


### PR DESCRIPTION
## Summary
- update POS currency formatter to sync hidden payment amount during input and keyup events
- ensure bubbled input events continue notifying Livewire for paid amount and change calculations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c667be9f88326ab8d203d9a9e2ad1)