### PR TITLE
Deprecate cash threshold visibility in location management

### DIFF
--- a/Modules/Setting/Resources/views/index.blade.php
+++ b/Modules/Setting/Resources/views/index.blade.php
@@ -88,10 +88,13 @@
 
                                 <div class="col-lg-4">
                                     <div class="form-group">
-                                        <label for="pos_default_cash_threshold">Ambang Kas Default POS</label>
+                                        <label for="pos_default_cash_threshold">
+                                            Ambang Kas Default POS
+                                            <span class="badge badge-warning align-middle ml-1">Deprecated</span>
+                                        </label>
                                         <input type="number" step="0.01" min="0" class="form-control" name="pos_default_cash_threshold"
                                                value="{{ old('pos_default_cash_threshold', $settings->pos_default_cash_threshold ?? 0) }}">
-                                        <small class="text-muted">Dipakai saat lokasi belum memiliki ambang kas khusus.</small>
+                                        <small class="text-muted">Fitur ini akan dihentikan; gunakan hanya bila masih perlu kompatibilitas ambang kas.</small>
                                     </div>
                                 </div>
                             </div>

--- a/Modules/Setting/Resources/views/locations/create.blade.php
+++ b/Modules/Setting/Resources/views/locations/create.blade.php
@@ -45,7 +45,10 @@
 
                                 <div class="col-lg-6">
                                     <div class="form-group">
-                                        <label for="pos_cash_threshold">Ambang Kas POS (opsional)</label>
+                                        <label for="pos_cash_threshold">
+                                            Ambang Kas POS (opsional)
+                                            <span class="badge badge-warning align-middle ml-1">Deprecated</span>
+                                        </label>
                                         <input
                                             type="number"
                                             step="0.01"
@@ -55,7 +58,7 @@
                                             value="{{ old('pos_cash_threshold', $defaultCashThreshold) }}"
                                             class="form-control @error('pos_cash_threshold') is-invalid @enderror"
                                         >
-                                        <small class="text-muted">Gunakan untuk memicu peringatan kas berlebih di lokasi ini.</small>
+                                        <small class="text-muted">Fitur ini akan dihentikan; biarkan kosong kecuali Anda masih membutuhkan batasan lama.</small>
                                         @error('pos_cash_threshold')
                                         <div class="invalid-feedback d-block">{{ $message }}</div>
                                         @enderror

--- a/Modules/Setting/Resources/views/locations/edit.blade.php
+++ b/Modules/Setting/Resources/views/locations/edit.blade.php
@@ -46,7 +46,10 @@
 
                                 <div class="col-lg-6">
                                     <div class="form-group">
-                                        <label for="pos_cash_threshold">Ambang Kas POS (opsional)</label>
+                                        <label for="pos_cash_threshold">
+                                            Ambang Kas POS (opsional)
+                                            <span class="badge badge-warning align-middle ml-1">Deprecated</span>
+                                        </label>
                                         <input
                                             type="number"
                                             step="0.01"
@@ -56,7 +59,7 @@
                                             class="form-control @error('pos_cash_threshold') is-invalid @enderror"
                                             value="{{ old('pos_cash_threshold', $location->pos_cash_threshold ?? $defaultCashThreshold) }}"
                                         >
-                                        <small class="text-muted">Biarkan kosong untuk mengikuti ambang default POS.</small>
+                                        <small class="text-muted">Fitur ini akan dihentikan; biarkan kosong untuk mengikuti setelan default.</small>
                                         @error('pos_cash_threshold')
                                         <div class="invalid-feedback d-block">{{ $message }}</div>
                                         @enderror

--- a/Modules/Setting/Resources/views/locations/index.blade.php
+++ b/Modules/Setting/Resources/views/locations/index.blade.php
@@ -32,7 +32,6 @@
                                     <th class="align-middle">No.</th>
                                     <th class="align-middle">Nama</th>
                                     <th class="align-middle">Bisnis</th>
-                                    <th class="align-middle">Ambang Kas</th>
                                     <th class="align-middle">POS</th>
                                     <th class="align-middle">Aksi</th>
                                 </tr>
@@ -43,12 +42,6 @@
                                         <td class="align-middle">{{ $key + 1 }}</td>
                                         <td class="align-middle">{{ $location->name }}</td>
                                         <td class="align-middle">{{ $location->setting->company_name }}</td>
-                                        <td class="align-middle">
-                                            @php
-                                                $threshold = $location->pos_cash_threshold ?? $location->setting?->pos_default_cash_threshold ?? 0;
-                                            @endphp
-                                            {{ $threshold > 0 ? format_currency($threshold) : '—' }}
-                                        </td>
                                         <td class="align-middle">
                                             @if($location->saleAssignment?->is_pos)
                                                 <span class="badge badge-success">Ya</span>
@@ -101,7 +94,7 @@
                     extend: 'print',
                     text: '<i class="bi bi-printer-fill"></i> Print',
                     title: "Locations",
-                    exportOptions: { columns: [0, 1, 2] }, // No., Nama, POS
+                    exportOptions: { columns: [0, 1, 2] }, // No., Nama, Bisnis
                     customize: function (win) {
                         $(win.document.body).find('h1').css('font-size', '15pt').css('text-align', 'center');
                         $(win.document.body).css('margin', '35px 25px');


### PR DESCRIPTION
## Summary
- hide the Ambang Kas column from the locations listing to remove it from the menu
- mark cash threshold inputs as deprecated in location create/edit forms and POS settings with warning copy

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c7f3475948326bd124efc3b6be432)